### PR TITLE
feat: add application/dicom+xml support for DICOMWeb compliance

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,7 @@ dependencies = [
     "websockets>=15.0.1",
     "pydicom>=3.0.1",
     "httpx>=0.28.1",
+    "pydicom-xml",
 ]
 
 [project.optional-dependencies]
@@ -105,6 +106,9 @@ warn_unreachable = true
 module = ["tests.*"]
 disallow_untyped_defs = false
 disallow_incomplete_defs = false
+
+[tool.uv.sources]
+pydicom-xml = { git = "https://github.com/sjswerdloff/pydicom-xml" }
 
 [dependency-groups]
 dev = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -108,12 +108,13 @@ disallow_untyped_defs = false
 disallow_incomplete_defs = false
 
 [tool.uv.sources]
-pydicom-xml = { git = "https://github.com/sjswerdloff/pydicom-xml" }
+pydicom-xml = { git = "https://github.com/sjswerdloff/pydicom-xml", rev = "02244d9f66097aff36bcbbc51c51a13997dfb7cd" }
 
 [dependency-groups]
 dev = [
     "pre-commit>=4.2.0",
     "pytest>=8.3.5",
     "pytest-asyncio>=0.26.0",
+    "pytest-json-report>=1.5.0",
     "ruff>=0.11.8",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -108,7 +108,7 @@ disallow_untyped_defs = false
 disallow_incomplete_defs = false
 
 [tool.uv.sources]
-pydicom-xml = { git = "https://github.com/sjswerdloff/pydicom-xml", rev = "02244d9f66097aff36bcbbc51c51a13997dfb7cd" }
+pydicom-xml = { git = "https://github.com/sjswerdloff/pydicom-xml", rev = "266cda9" }
 
 [dependency-groups]
 dev = [

--- a/pyupsrs/api/resources/workitems.py
+++ b/pyupsrs/api/resources/workitems.py
@@ -12,6 +12,12 @@ from falcon.asgi import BoundedStream
 from pydicom import DataElement, Dataset, datadict
 
 from pyupsrs.api.serializers.dicom_json import deserialize_workitem
+from pyupsrs.api.serializers.dicom_xml import (
+    deserialize_request_body,
+    negotiate_content_type,
+    serialize_dataset,
+    serialize_dataset_list,
+)
 from pyupsrs.config import Config
 from pyupsrs.domain.models.ups import WorkItem, WorkItemStatus
 from pyupsrs.domain.services import workitem_service as svc_workitem_service
@@ -113,7 +119,7 @@ class DICOMJSONHandler:
             The parsed request body.
 
         """
-        return self.deserialize()
+        return self.deserialize(stream, content_type, content_length)
 
     async def serialize_async(self, media: dict[str, Any], content_type: str) -> bytes:
         """
@@ -197,18 +203,21 @@ class WorkItemsResource(LoggerMixin):
                 limit=limit,
             )
 
-        resp.content_type = "application/dicom+json"
+        resp.content_type = negotiate_content_type(req)
         if workitem_list and len(workitem_list) > 0 and workitem_list[0] is not None and workitem_list[0].ds is not None:
             dataset_list = [x.ds for x in workitem_list]
             resp.status = falcon.HTTP_200
-            json_response_text = ""
             try:
-                json_response_text = serialise_list_of_ds_to_json(dataset_list=dataset_list)
+                data, resp.content_type = serialize_dataset_list(dataset_list, resp.content_type)
             except Exception as e:
-                print(f"Failed to serialise result as json string: {e}")
+                print(f"Failed to serialise result: {e}")
                 resp.status = falcon.HTTP_404
+                return
 
-            resp.text = json_response_text
+            if isinstance(data, bytes):
+                resp.data = data
+            else:
+                resp.text = data
 
         else:
             resp.status = falcon.HTTP_404
@@ -227,18 +236,21 @@ class WorkItemsResource(LoggerMixin):
             base_uri = get_base_uri(req=req)
             body = await req.stream.read()
             if not body:
-                raise falcon.HTTPBadRequest(title="Empty request body", description="A valid DICOM JSON dataset is required")
+                raise falcon.HTTPBadRequest(title="Empty request body", description="A valid DICOM dataset is required")
 
-            # Parse the JSON body
-            try:
-                data = json.loads(body)
-            except json.JSONDecodeError as e:
-                raise falcon.HTTPBadRequest(title="Invalid JSON", description="Request body must be valid JSON") from e
+            # Parse the body based on content type
+            parsed = deserialize_request_body(body, req.content_type)
+            if isinstance(parsed, Dataset):
+                workitem = WorkItem(ds=parsed)
+            else:
+                try:
+                    workitem = deserialize_workitem(parsed)
+                except Exception as e:
+                    raise falcon.HTTPBadRequest(
+                        title="Invalid DICOM JSON", description="Request body must be valid DICOM JSON"
+                    ) from e
 
-            json_dicom = data
-            workitem = deserialize_workitem(json_dicom)
-
-            resp.content_type = "application/dicom+json"
+            resp.content_type = negotiate_content_type(req)
 
             if self.workitem_service.workitem_repository.get_by_uid(workitem.uid):
                 msg = f"Error: 299 {base_uri}: Can not create the workitem because the workitem UID: {workitem.uid} exists"
@@ -252,6 +264,8 @@ class WorkItemsResource(LoggerMixin):
                 resp_media = json.dumps(workitem_response)
                 resp.text = resp_media
 
+        except falcon.HTTPError:
+            raise
         except Exception as e:
             # Get a detailed traceback for debugging on the server side
             print(traceback.format_exc())
@@ -292,18 +306,22 @@ class WorkItemResource(LoggerMixin):
         else:
             resp.status = falcon.HTTP_404
 
-        resp.content_type = "application/dicom+json"
+        resp.content_type = negotiate_content_type(req)
         if workitem is not None and workitem.ds is not None:
             resp.status = falcon.HTTP_200
-            json_response_text = ""
             try:
-                json_response_text = workitem.ds.to_json()
+                data, resp.content_type = serialize_dataset(workitem.ds, resp.content_type)
             except Exception as e:
                 # Get a detailed traceback for debugging on the server side
                 print(traceback.format_exc())
-                print(f"Failed to serialise result as json string: {e}")
+                print(f"Failed to serialise result: {e}")
+                resp.status = falcon.HTTP_500
+                return
 
-            resp.text = json_response_text
+            if isinstance(data, bytes):
+                resp.data = data
+            else:
+                resp.text = data
 
         else:
             resp.status = falcon.HTTP_404

--- a/pyupsrs/api/resources/workitems.py
+++ b/pyupsrs/api/resources/workitems.py
@@ -4,6 +4,7 @@ import json
 import traceback
 from datetime import datetime
 from typing import Any
+from xml.etree import ElementTree as ET
 
 import falcon
 import falcon.request
@@ -108,7 +109,10 @@ class DICOMJSONHandler:
 
     async def deserialize_async(self, stream: BoundedStream, content_type: str, content_length: int) -> dict[str, Any]:
         """
-        Deserialize the request body from application/dicom+json.
+        Deserialize the request body from application/dicom+json (async).
+
+        Uses ``await stream.read()`` to consume the full body on ASGI without
+        blocking the event loop.
 
         Args:
             stream: The request body stream.
@@ -119,7 +123,8 @@ class DICOMJSONHandler:
             The parsed request body.
 
         """
-        return self.deserialize(stream, content_type, content_length)
+        body = await stream.read()
+        return json.loads(body) if body else {}
 
     async def serialize_async(self, media: dict[str, Any], content_type: str) -> bytes:
         """
@@ -211,7 +216,7 @@ class WorkItemsResource(LoggerMixin):
                 data, resp.content_type = serialize_dataset_list(dataset_list, resp.content_type)
             except Exception as e:
                 print(f"Failed to serialise result: {e}")
-                resp.status = falcon.HTTP_404
+                resp.status = falcon.HTTP_500
                 return
 
             if isinstance(data, bytes):
@@ -238,8 +243,14 @@ class WorkItemsResource(LoggerMixin):
             if not body:
                 raise falcon.HTTPBadRequest(title="Empty request body", description="A valid DICOM dataset is required")
 
-            # Parse the body based on content type
-            parsed = deserialize_request_body(body, req.content_type)
+            # Parse the body based on content type — return 400 for malformed input
+            try:
+                parsed = deserialize_request_body(body, req.content_type)
+            except (json.JSONDecodeError, ET.ParseError, Exception) as e:
+                raise falcon.HTTPBadRequest(
+                    title="Invalid request body",
+                    description=f"Request body must be valid DICOM JSON or XML: {e}",
+                ) from e
             if isinstance(parsed, Dataset):
                 workitem = WorkItem(ds=parsed)
             else:

--- a/pyupsrs/api/resources/workitems.py
+++ b/pyupsrs/api/resources/workitems.py
@@ -247,9 +247,10 @@ class WorkItemsResource(LoggerMixin):
             try:
                 parsed = deserialize_request_body(body, req.content_type)
             except (json.JSONDecodeError, ET.ParseError, Exception) as e:
+                self.logger.error("Failed to parse request body: %s", e)
                 raise falcon.HTTPBadRequest(
                     title="Invalid request body",
-                    description=f"Request body must be valid DICOM JSON or XML: {e}",
+                    description="Request body must be valid DICOM JSON or XML",
                 ) from e
             if isinstance(parsed, Dataset):
                 workitem = WorkItem(ds=parsed)
@@ -270,10 +271,15 @@ class WorkItemsResource(LoggerMixin):
                 resp.append_header("Warning", msg)
             else:
                 self.workitem_service.create_workitem(workitem=workitem)
-                workitem_response = {"00080018": {"Value": [workitem.ds.SOPInstanceUID], "vr": "UI"}}
+                # Build a minimal response Dataset with the created SOP Instance UID
+                response_ds = Dataset()
+                response_ds.SOPInstanceUID = workitem.ds.SOPInstanceUID
                 resp.status = falcon.HTTP_201
-                resp_media = json.dumps(workitem_response)
-                resp.text = resp_media
+                data, resp.content_type = serialize_dataset(response_ds, resp.content_type)
+                if isinstance(data, bytes):
+                    resp.data = data
+                else:
+                    resp.text = data
 
         except falcon.HTTPError:
             raise

--- a/pyupsrs/api/resources/workitems.py
+++ b/pyupsrs/api/resources/workitems.py
@@ -246,7 +246,7 @@ class WorkItemsResource(LoggerMixin):
             # Parse the body based on content type — return 400 for malformed input
             try:
                 parsed = deserialize_request_body(body, req.content_type)
-            except (json.JSONDecodeError, ET.ParseError, Exception) as e:
+            except (json.JSONDecodeError, ET.ParseError, ValueError) as e:
                 self.logger.error("Failed to parse request body: %s", e)
                 raise falcon.HTTPBadRequest(
                     title="Invalid request body",

--- a/pyupsrs/api/serializers/dicom_xml.py
+++ b/pyupsrs/api/serializers/dicom_xml.py
@@ -1,0 +1,159 @@
+"""
+Serializers for DICOM+XML content type support.
+
+Provides handlers and helpers for application/dicom+xml media type,
+implementing the Native DICOM Model (PS3.19) XML format.
+"""
+
+import json
+from typing import Any
+
+import falcon
+from falcon.asgi import BoundedStream
+from pydicom import Dataset
+from pydicom_xml import from_xml, to_xml
+
+
+class DICOMXMLHandler:
+    """Handler for application/dicom+xml media type."""
+
+    def deserialize(self, stream: BoundedStream, content_type: str, content_length: int) -> Dataset:
+        """
+        Deserialize the request body from application/dicom+xml.
+
+        Args:
+            stream: The request body stream.
+            content_type: The content type of the request.
+            content_length: The length of the request body.
+
+        Returns:
+            The parsed Dataset.
+
+        """
+        body = stream.read(content_length or 0)
+        if not body:
+            return Dataset()
+        return from_xml(body)
+
+    def serialize(self, media: Dataset | bytes, content_type: str) -> bytes:
+        """
+        Serialize the media object to application/dicom+xml.
+
+        Args:
+            media: The Dataset or pre-serialized bytes to serialize.
+            content_type: The content type to serialize to.
+
+        Returns:
+            The serialized media as bytes.
+
+        """
+        if isinstance(media, Dataset):
+            return to_xml(media)
+        return media  # already bytes
+
+    async def deserialize_async(self, stream: BoundedStream, content_type: str, content_length: int) -> Dataset:
+        """
+        Deserialize the request body from application/dicom+xml (async).
+
+        Args:
+            stream: The request body stream.
+            content_type: The content type of the request.
+            content_length: The length of the request body.
+
+        Returns:
+            The parsed Dataset.
+
+        """
+        return self.deserialize(stream, content_type, content_length)
+
+    async def serialize_async(self, media: Dataset | bytes, content_type: str) -> bytes:
+        """
+        Serialize the media object to application/dicom+xml (async).
+
+        Args:
+            media: The Dataset or pre-serialized bytes to serialize.
+            content_type: The content type to serialize to.
+
+        Returns:
+            The serialized media as bytes.
+
+        """
+        return self.serialize(media, content_type)
+
+
+SUPPORTED_DICOM_MEDIA_TYPES = ["application/dicom+json", "application/dicom+xml"]
+
+
+def negotiate_content_type(req: falcon.Request) -> str:
+    """
+    Determine response content type from Accept header.
+
+    Defaults to application/dicom+json if no preference or unsupported type requested.
+
+    Args:
+        req: The incoming Falcon request.
+
+    Returns:
+        The negotiated content type string.
+
+    """
+    preferred = req.client_prefers(SUPPORTED_DICOM_MEDIA_TYPES)
+    return preferred or "application/dicom+json"
+
+
+def serialize_dataset(ds: Dataset, content_type: str) -> tuple[bytes | str, str]:
+    """
+    Serialize a Dataset to the negotiated format.
+
+    Args:
+        ds: The pydicom Dataset to serialize.
+        content_type: The negotiated content type (json or xml).
+
+    Returns:
+        A tuple of (serialized_data, content_type).
+
+    """
+    if "xml" in content_type:
+        return to_xml(ds), "application/dicom+xml"
+    return ds.to_json(), "application/dicom+json"
+
+
+def serialize_dataset_list(datasets: list[Dataset], content_type: str) -> tuple[bytes | str, str]:
+    """
+    Serialize a list of Datasets to the negotiated format.
+
+    For JSON: single JSON array of DICOM JSON objects.
+    For XML: concatenated XML documents, one per dataset, separated by newline.
+
+    Args:
+        datasets: List of pydicom Datasets to serialize.
+        content_type: The negotiated content type (json or xml).
+
+    Returns:
+        A tuple of (serialized_data, content_type).
+
+    """
+    if "xml" in content_type:
+        if not datasets:
+            return b"", "application/dicom+xml"
+        xml_parts = [to_xml(ds) for ds in datasets]
+        return b"\n".join(xml_parts), "application/dicom+xml"
+    list_of_json = [ds.to_json() for ds in datasets]
+    return "[" + ",".join(list_of_json) + "]", "application/dicom+json"
+
+
+def deserialize_request_body(body: bytes, content_type: str | None) -> dict[str, Any] | Dataset:
+    """
+    Deserialize request body based on content type.
+
+    Args:
+        body: Raw request body bytes.
+        content_type: The Content-Type header value.
+
+    Returns:
+        A dict for JSON content types, a Dataset for XML content types.
+
+    """
+    if content_type and "xml" in content_type:
+        return from_xml(body) if body else Dataset()
+    return json.loads(body) if body else {}

--- a/pyupsrs/api/serializers/dicom_xml.py
+++ b/pyupsrs/api/serializers/dicom_xml.py
@@ -148,13 +148,9 @@ def serialize_dataset_list(datasets: list[Dataset], content_type: str) -> tuple[
         parts = []
         for ds in datasets:
             xml_bytes = to_xml(ds)
-            part = (
-                f"--{boundary}\r\n"
-                f"Content-Type: application/dicom+xml\r\n"
-                f"\r\n"
-            ).encode("utf-8") + xml_bytes + b"\r\n"
+            part = (f"--{boundary}\r\nContent-Type: application/dicom+xml\r\n\r\n").encode() + xml_bytes + b"\r\n"
             parts.append(part)
-        body = b"".join(parts) + f"--{boundary}--\r\n".encode("utf-8")
+        body = b"".join(parts) + f"--{boundary}--\r\n".encode()
         multipart_content_type = f'multipart/related; type="application/dicom+xml"; boundary={boundary}'
         return body, multipart_content_type
     list_of_json = [ds.to_json() for ds in datasets]

--- a/pyupsrs/api/serializers/dicom_xml.py
+++ b/pyupsrs/api/serializers/dicom_xml.py
@@ -30,7 +30,7 @@ class DICOMXMLHandler:
             The parsed Dataset.
 
         """
-        body = stream.read(content_length or 0)
+        body = stream.read()
         if not body:
             return Dataset()
         return from_xml(body)
@@ -55,6 +55,9 @@ class DICOMXMLHandler:
         """
         Deserialize the request body from application/dicom+xml (async).
 
+        Uses ``await stream.read()`` to consume the full body on ASGI without
+        blocking the event loop.
+
         Args:
             stream: The request body stream.
             content_type: The content type of the request.
@@ -64,7 +67,10 @@ class DICOMXMLHandler:
             The parsed Dataset.
 
         """
-        return self.deserialize(stream, content_type, content_length)
+        body = await stream.read()
+        if not body:
+            return Dataset()
+        return from_xml(body)
 
     async def serialize_async(self, media: Dataset | bytes, content_type: str) -> bytes:
         """
@@ -123,7 +129,10 @@ def serialize_dataset_list(datasets: list[Dataset], content_type: str) -> tuple[
     Serialize a list of Datasets to the negotiated format.
 
     For JSON: single JSON array of DICOM JSON objects.
-    For XML: concatenated XML documents, one per dataset, separated by newline.
+    For XML: each Dataset is serialized as a standalone XML document,
+    separated by newlines. Note: per PS3.18, multiple XML results should
+    use multipart/related framing. This simplified concatenation works
+    for single-result responses. Full multipart support is a future enhancement.
 
     Args:
         datasets: List of pydicom Datasets to serialize.

--- a/pyupsrs/api/serializers/dicom_xml.py
+++ b/pyupsrs/api/serializers/dicom_xml.py
@@ -129,24 +129,34 @@ def serialize_dataset_list(datasets: list[Dataset], content_type: str) -> tuple[
     Serialize a list of Datasets to the negotiated format.
 
     For JSON: single JSON array of DICOM JSON objects.
-    For XML: each Dataset is serialized as a standalone XML document,
-    separated by newlines. Note: per PS3.18, multiple XML results should
-    use multipart/related framing. This simplified concatenation works
-    for single-result responses. Full multipart support is a future enhancement.
+    For XML: multipart/related with one NativeDicomModel document per part,
+    per PS3.18 QIDO-RS response specification.
 
     Args:
         datasets: List of pydicom Datasets to serialize.
         content_type: The negotiated content type (json or xml).
 
     Returns:
-        A tuple of (serialized_data, content_type).
+        A tuple of (serialized_data, actual_content_type).
+        For XML, the content_type includes the multipart boundary.
 
     """
     if "xml" in content_type:
         if not datasets:
             return b"", "application/dicom+xml"
-        xml_parts = [to_xml(ds) for ds in datasets]
-        return b"\n".join(xml_parts), "application/dicom+xml"
+        boundary = "dicom-xml-boundary"
+        parts = []
+        for ds in datasets:
+            xml_bytes = to_xml(ds)
+            part = (
+                f"--{boundary}\r\n"
+                f"Content-Type: application/dicom+xml\r\n"
+                f"\r\n"
+            ).encode("utf-8") + xml_bytes + b"\r\n"
+            parts.append(part)
+        body = b"".join(parts) + f"--{boundary}--\r\n".encode("utf-8")
+        multipart_content_type = f'multipart/related; type="application/dicom+xml"; boundary={boundary}'
+        return body, multipart_content_type
     list_of_json = [ds.to_json() for ds in datasets]
     return "[" + ",".join(list_of_json) + "]", "application/dicom+json"
 

--- a/pyupsrs/api/serializers/dicom_xml.py
+++ b/pyupsrs/api/serializers/dicom_xml.py
@@ -11,7 +11,7 @@ from typing import Any
 import falcon
 from falcon.asgi import BoundedStream
 from pydicom import Dataset
-from pydicom_xml import from_xml, to_xml
+from pydicom_xml import datasets_to_multipart_xml, from_xml, to_xml
 
 
 class DICOMXMLHandler:
@@ -144,15 +144,7 @@ def serialize_dataset_list(datasets: list[Dataset], content_type: str) -> tuple[
     if "xml" in content_type:
         if not datasets:
             return b"", "application/dicom+xml"
-        boundary = "dicom-xml-boundary"
-        parts = []
-        for ds in datasets:
-            xml_bytes = to_xml(ds)
-            part = (f"--{boundary}\r\nContent-Type: application/dicom+xml\r\n\r\n").encode() + xml_bytes + b"\r\n"
-            parts.append(part)
-        body = b"".join(parts) + f"--{boundary}--\r\n".encode()
-        multipart_content_type = f'multipart/related; type="application/dicom+xml"; boundary={boundary}'
-        return body, multipart_content_type
+        return datasets_to_multipart_xml(datasets)
     list_of_json = [ds.to_json() for ds in datasets]
     return "[" + ",".join(list_of_json) + "]", "application/dicom+json"
 

--- a/pyupsrs/app.py
+++ b/pyupsrs/app.py
@@ -18,6 +18,7 @@ from pyupsrs.api.middleware.logging import LoggingMiddleware
 from pyupsrs.api.resources.subscriptions import SubscriptionResource, SubscriptionSuspendResource
 from pyupsrs.api.resources.websocket_resource import WebSocketResource
 from pyupsrs.api.resources.workitems import DICOMJSONHandler, WorkItemResource, WorkItemsResource, WorkItemStateResource
+from pyupsrs.api.serializers.dicom_xml import DICOMXMLHandler
 from pyupsrs.config import get_config
 from pyupsrs.domain.services.service_provider import ServiceProvider
 from pyupsrs.utils.class_logger import configure_logging
@@ -49,11 +50,13 @@ def create_app() -> App:
     app.req_options.media_handlers.update(
         {
             "application/dicom+json": DICOMJSONHandler(),
+            "application/dicom+xml": DICOMXMLHandler(),
         }
     )
     app.resp_options.media_handlers.update(
         {
             "application/dicom+json": DICOMJSONHandler(),
+            "application/dicom+xml": DICOMXMLHandler(),
         }
     )
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -41,6 +41,7 @@ def falcon_app() -> App:
     from pyupsrs.api.resources.subscriptions import SubscriptionResource, SubscriptionSuspendResource
     from pyupsrs.api.resources.websocket_resource import WebSocketResource
     from pyupsrs.api.resources.workitems import DICOMJSONHandler, WorkItemResource, WorkItemsResource, WorkItemStateResource
+    from pyupsrs.api.serializers.dicom_xml import DICOMXMLHandler
     from pyupsrs.config import get_config
     from pyupsrs.domain.services.service_provider import ServiceProvider
     from pyupsrs.utils.class_logger import configure_logging
@@ -72,11 +73,13 @@ def falcon_app() -> App:
     app.req_options.media_handlers.update(
         {
             "application/dicom+json": DICOMJSONHandler(),
+            "application/dicom+xml": DICOMXMLHandler(),
         }
     )
     app.resp_options.media_handlers.update(
         {
             "application/dicom+json": DICOMJSONHandler(),
+            "application/dicom+xml": DICOMXMLHandler(),
         }
     )
 

--- a/tests/integration/transactions/test_dicom_xml_content_negotiation.py
+++ b/tests/integration/transactions/test_dicom_xml_content_negotiation.py
@@ -1,0 +1,290 @@
+"""
+Integration tests for DICOM XML content negotiation in UPS-RS endpoints.
+
+Tests verify:
+- GET /workitems with Accept: application/dicom+xml returns XML content type
+- GET /workitems with Accept: application/dicom+json returns JSON (existing behavior preserved)
+- GET /workitems with no Accept header defaults to JSON
+- GET /workitems/{uid} with Accept: application/dicom+xml returns XML
+- POST /workitems with Content-Type: application/dicom+xml body is parsed correctly
+- XML response is valid DICOM XML parseable by from_xml()
+- Round-trip: create workitem with JSON, retrieve with XML Accept header, parse XML response
+"""
+
+import json
+from typing import Any
+
+import pytest
+from falcon.testing.client import TestClient
+from pydicom import Dataset
+from pydicom.uid import generate_uid
+from pydicom_xml import from_xml, to_xml
+
+from tests.integration.transactions.test_workitem_transactions import create_workitem_helper, retrieve_workitem_helper
+
+
+def _extract_sop_instance_uid_from_workitem(workitem_dict: dict[str, Any]) -> str:
+    """Extract SOP Instance UID from a DICOM JSON workitem dict."""
+    return workitem_dict["00080018"]["Value"][0]
+
+
+@pytest.fixture()
+def base_workitem_json() -> dict[str, Any]:
+    """Return a minimal valid UPS workitem as a DICOM JSON dict with a fresh UID."""
+    from datetime import datetime, timedelta
+
+    return {
+        "00080016": {"vr": "UI", "Value": ["1.2.840.10008.5.1.4.34.6.1"]},
+        "00080018": {"vr": "UI", "Value": [str(generate_uid())]},
+        "00080054": {"vr": "AE", "Value": ["TESTSTATION"]},
+        "00080056": {"vr": "CS", "Value": ["READY"]},
+        "00100010": {"vr": "PN", "Value": [{"Alphabetic": "XML^TEST^PATIENT"}]},
+        "00100020": {"vr": "LO", "Value": ["XML-TEST-001"]},
+        "00100030": {"vr": "DA", "Value": ["20230101"]},
+        "00404041": {"vr": "CS", "Value": ["READY"]},
+        "00404005": {"vr": "DT", "Value": [datetime.now().strftime("%Y%m%d%H%M%S")]},
+        "00404010": {"vr": "DT", "Value": [(datetime.now() + timedelta(hours=1)).strftime("%Y%m%d%H%M%S")]},
+        "00404025": {
+            "vr": "SQ",
+            "Value": [
+                {
+                    "00080100": {"vr": "SH", "Value": ["XML_STATION"]},
+                    "00080102": {"vr": "SH", "Value": ["99TEST"]},
+                    "00080104": {"vr": "LO", "Value": ["XML Test Station"]},
+                }
+            ],
+        },
+        "00404026": {
+            "vr": "SQ",
+            "Value": [
+                {
+                    "00080100": {"vr": "SH", "Value": ["STATION_CLASS"]},
+                    "00080102": {"vr": "SH", "Value": ["99TEST"]},
+                    "00080104": {"vr": "LO", "Value": ["Test Station Class"]},
+                }
+            ],
+        },
+        "00404027": {
+            "vr": "SQ",
+            "Value": [
+                {
+                    "00080100": {"vr": "SH", "Value": ["TEST_LOCATION"]},
+                    "00080102": {"vr": "SH", "Value": ["99TEST"]},
+                    "00080104": {"vr": "LO", "Value": ["Test Location"]},
+                }
+            ],
+        },
+        "00404018": {
+            "vr": "SQ",
+            "Value": [
+                {
+                    "00080100": {"vr": "SH", "Value": ["TEST_WORKITEM"]},
+                    "00080102": {"vr": "SH", "Value": ["99TEST"]},
+                    "00080104": {"vr": "LO", "Value": ["Test Workitem"]},
+                }
+            ],
+        },
+        "00741000": {"vr": "CS", "Value": ["SCHEDULED"]},
+    }
+
+
+class TestGetWorkitemsXmlAccept:
+    """Tests for GET /workitems with XML Accept header."""
+
+    def test_get_workitems_xml_accept_returns_xml_content_type(
+        self, client: TestClient, base_workitem_json: dict[str, Any]
+    ) -> None:
+        """Contract: GET /workitems with XML Accept returns application/dicom+xml content type."""
+        # First create a workitem so there is something to retrieve
+        create_workitem_helper(client, base_workitem_json)
+
+        resp = client.simulate_get("/workitems", headers={"Accept": "application/dicom+xml"})
+
+        assert resp.status_code == 200
+        assert "application/dicom+xml" in resp.headers.get("content-type", "")
+
+    def test_get_workitems_xml_accept_body_is_valid_dicom_xml(
+        self, client: TestClient, base_workitem_json: dict[str, Any]
+    ) -> None:
+        """Contract: GET /workitems with XML Accept returns parseable DICOM XML."""
+        create_workitem_helper(client, base_workitem_json)
+
+        resp = client.simulate_get("/workitems", headers={"Accept": "application/dicom+xml"})
+
+        assert resp.status_code == 200
+        # Should be parseable as DICOM XML
+        ds = from_xml(resp.content)
+        assert isinstance(ds, Dataset)
+
+    def test_get_workitems_json_accept_returns_json_content_type(
+        self, client: TestClient, base_workitem_json: dict[str, Any]
+    ) -> None:
+        """Contract: GET /workitems with JSON Accept still returns JSON (existing behavior)."""
+        create_workitem_helper(client, base_workitem_json)
+
+        resp = client.simulate_get("/workitems", headers={"Accept": "application/dicom+json"})
+
+        assert resp.status_code == 200
+        assert "application/dicom+json" in resp.headers.get("content-type", "")
+
+    def test_get_workitems_json_accept_body_is_valid_json(
+        self, client: TestClient, base_workitem_json: dict[str, Any]
+    ) -> None:
+        """Contract: GET /workitems with JSON Accept returns parseable JSON array."""
+        create_workitem_helper(client, base_workitem_json)
+
+        resp = client.simulate_get("/workitems", headers={"Accept": "application/dicom+json"})
+
+        assert resp.status_code == 200
+        parsed = json.loads(resp.text)
+        assert isinstance(parsed, list)
+
+    def test_get_workitems_no_accept_defaults_to_json(
+        self, client: TestClient, base_workitem_json: dict[str, Any]
+    ) -> None:
+        """Contract: GET /workitems with no Accept header defaults to JSON."""
+        create_workitem_helper(client, base_workitem_json)
+
+        resp = client.simulate_get("/workitems")
+
+        assert resp.status_code == 200
+        assert "application/dicom+json" in resp.headers.get("content-type", "")
+
+
+class TestGetWorkitemXmlAccept:
+    """Tests for GET /workitems/{uid} with XML Accept header."""
+
+    def test_get_workitem_xml_accept_returns_xml_content_type(
+        self, client: TestClient, base_workitem_json: dict[str, Any]
+    ) -> None:
+        """Contract: GET /workitems/{uid} with XML Accept returns application/dicom+xml."""
+        uid = _extract_sop_instance_uid_from_workitem(base_workitem_json)
+        create_workitem_helper(client, base_workitem_json)
+
+        resp = client.simulate_get(f"/workitems/{uid}", headers={"Accept": "application/dicom+xml"})
+
+        assert resp.status_code == 200
+        assert "application/dicom+xml" in resp.headers.get("content-type", "")
+
+    def test_get_workitem_xml_accept_body_is_valid_dicom_xml(
+        self, client: TestClient, base_workitem_json: dict[str, Any]
+    ) -> None:
+        """Contract: GET /workitems/{uid} with XML Accept returns parseable DICOM XML."""
+        uid = _extract_sop_instance_uid_from_workitem(base_workitem_json)
+        create_workitem_helper(client, base_workitem_json)
+
+        resp = client.simulate_get(f"/workitems/{uid}", headers={"Accept": "application/dicom+xml"})
+
+        assert resp.status_code == 200
+        ds = from_xml(resp.content)
+        assert isinstance(ds, Dataset)
+
+    def test_get_workitem_json_accept_still_works(
+        self, client: TestClient, base_workitem_json: dict[str, Any]
+    ) -> None:
+        """Contract: GET /workitems/{uid} with JSON Accept still returns JSON."""
+        uid = _extract_sop_instance_uid_from_workitem(base_workitem_json)
+        create_workitem_helper(client, base_workitem_json)
+
+        resp = retrieve_workitem_helper(client, uid)
+
+        assert resp.status_code == 200
+        assert "application/dicom+json" in resp.headers.get("content-type", "")
+        parsed = json.loads(resp.text)
+        assert isinstance(parsed, dict)
+
+
+class TestPostWorkitemXmlBody:
+    """Tests for POST /workitems with XML Content-Type."""
+
+    def test_post_workitem_xml_body_returns_201(
+        self, client: TestClient, base_workitem_json: dict[str, Any]
+    ) -> None:
+        """Contract: POST /workitems with XML body creates a workitem (HTTP 201)."""
+        # Build a Dataset from the JSON fixture, then convert to XML
+        from pydicom.dataset import Dataset as PydcmDataset
+
+        ds = PydcmDataset.from_json(base_workitem_json)
+        xml_body = to_xml(ds)
+
+        resp = client.simulate_post(
+            "/workitems",
+            body=xml_body,
+            headers={"Content-Type": "application/dicom+xml"},
+        )
+
+        assert resp.status_code == 201
+
+    def test_post_workitem_xml_body_stores_retrievable_workitem(
+        self, client: TestClient, base_workitem_json: dict[str, Any]
+    ) -> None:
+        """Contract: Workitem POSTed with XML body can be retrieved with JSON Accept."""
+        uid = _extract_sop_instance_uid_from_workitem(base_workitem_json)
+        from pydicom.dataset import Dataset as PydcmDataset
+
+        ds = PydcmDataset.from_json(base_workitem_json)
+        xml_body = to_xml(ds)
+
+        client.simulate_post(
+            "/workitems",
+            body=xml_body,
+            headers={"Content-Type": "application/dicom+xml"},
+        )
+
+        # Should be retrievable via JSON Accept
+        resp = retrieve_workitem_helper(client, uid)
+        assert resp.status_code == 200
+
+
+class TestRoundTripXmlJson:
+    """Round-trip tests: create with JSON, retrieve with XML; and vice versa."""
+
+    def test_create_json_retrieve_xml_round_trip(
+        self, client: TestClient, base_workitem_json: dict[str, Any]
+    ) -> None:
+        """Contract: Workitem created with JSON can be retrieved and parsed as valid DICOM XML."""
+        uid = _extract_sop_instance_uid_from_workitem(base_workitem_json)
+        create_workitem_helper(client, base_workitem_json)
+
+        resp = client.simulate_get(f"/workitems/{uid}", headers={"Accept": "application/dicom+xml"})
+
+        assert resp.status_code == 200
+        ds = from_xml(resp.content)
+        assert isinstance(ds, Dataset)
+        # PatientID should survive the round-trip
+        assert ds.PatientID == "XML-TEST-001"
+
+    def test_create_json_retrieve_list_as_xml(
+        self, client: TestClient, base_workitem_json: dict[str, Any]
+    ) -> None:
+        """Contract: Workitem list created with JSON can be retrieved as valid DICOM XML."""
+        create_workitem_helper(client, base_workitem_json)
+
+        resp = client.simulate_get("/workitems", headers={"Accept": "application/dicom+xml"})
+
+        assert resp.status_code == 200
+        # The first XML document (before any newline separator) should be parseable
+        first_doc = resp.content.split(b"\n<?xml")[0]
+        ds = from_xml(first_doc)
+        assert isinstance(ds, Dataset)
+
+    def test_create_xml_retrieve_xml_round_trip(
+        self, client: TestClient, base_workitem_json: dict[str, Any]
+    ) -> None:
+        """Contract: Workitem POSTed with XML body can be retrieved as XML with same patient data."""
+        uid = _extract_sop_instance_uid_from_workitem(base_workitem_json)
+        from pydicom.dataset import Dataset as PydcmDataset
+
+        ds = PydcmDataset.from_json(base_workitem_json)
+        xml_body = to_xml(ds)
+
+        client.simulate_post(
+            "/workitems",
+            body=xml_body,
+            headers={"Content-Type": "application/dicom+xml"},
+        )
+
+        resp = client.simulate_get(f"/workitems/{uid}", headers={"Accept": "application/dicom+xml"})
+        assert resp.status_code == 200
+        retrieved_ds = from_xml(resp.content)
+        assert retrieved_ds.PatientID == "XML-TEST-001"

--- a/tests/integration/transactions/test_dicom_xml_content_negotiation.py
+++ b/tests/integration/transactions/test_dicom_xml_content_negotiation.py
@@ -139,9 +139,7 @@ class TestGetWorkitemsXmlAccept:
         parsed = json.loads(resp.text)
         assert isinstance(parsed, list)
 
-    def test_get_workitems_no_accept_defaults_to_json(
-        self, client: TestClient, base_workitem_json: dict[str, Any]
-    ) -> None:
+    def test_get_workitems_no_accept_defaults_to_json(self, client: TestClient, base_workitem_json: dict[str, Any]) -> None:
         """Contract: GET /workitems with no Accept header defaults to JSON."""
         create_workitem_helper(client, base_workitem_json)
 
@@ -179,9 +177,7 @@ class TestGetWorkitemXmlAccept:
         ds = from_xml(resp.content)
         assert isinstance(ds, Dataset)
 
-    def test_get_workitem_json_accept_still_works(
-        self, client: TestClient, base_workitem_json: dict[str, Any]
-    ) -> None:
+    def test_get_workitem_json_accept_still_works(self, client: TestClient, base_workitem_json: dict[str, Any]) -> None:
         """Contract: GET /workitems/{uid} with JSON Accept still returns JSON."""
         uid = _extract_sop_instance_uid_from_workitem(base_workitem_json)
         create_workitem_helper(client, base_workitem_json)
@@ -197,9 +193,7 @@ class TestGetWorkitemXmlAccept:
 class TestPostWorkitemXmlBody:
     """Tests for POST /workitems with XML Content-Type."""
 
-    def test_post_workitem_xml_body_returns_201(
-        self, client: TestClient, base_workitem_json: dict[str, Any]
-    ) -> None:
+    def test_post_workitem_xml_body_returns_201(self, client: TestClient, base_workitem_json: dict[str, Any]) -> None:
         """Contract: POST /workitems with XML body creates a workitem (HTTP 201)."""
         # Build a Dataset from the JSON fixture, then convert to XML
         from pydicom.dataset import Dataset as PydcmDataset
@@ -239,9 +233,7 @@ class TestPostWorkitemXmlBody:
 class TestRoundTripXmlJson:
     """Round-trip tests: create with JSON, retrieve with XML; and vice versa."""
 
-    def test_create_json_retrieve_xml_round_trip(
-        self, client: TestClient, base_workitem_json: dict[str, Any]
-    ) -> None:
+    def test_create_json_retrieve_xml_round_trip(self, client: TestClient, base_workitem_json: dict[str, Any]) -> None:
         """Contract: Workitem created with JSON can be retrieved and parsed as valid DICOM XML."""
         uid = _extract_sop_instance_uid_from_workitem(base_workitem_json)
         create_workitem_helper(client, base_workitem_json)
@@ -254,9 +246,7 @@ class TestRoundTripXmlJson:
         # PatientID should survive the round-trip
         assert ds.PatientID == "XML-TEST-001"
 
-    def test_create_json_retrieve_list_as_xml(
-        self, client: TestClient, base_workitem_json: dict[str, Any]
-    ) -> None:
+    def test_create_json_retrieve_list_as_xml(self, client: TestClient, base_workitem_json: dict[str, Any]) -> None:
         """Contract: Workitem list created with JSON can be retrieved as valid DICOM XML."""
         create_workitem_helper(client, base_workitem_json)
 
@@ -268,9 +258,7 @@ class TestRoundTripXmlJson:
         ds = from_xml(first_doc)
         assert isinstance(ds, Dataset)
 
-    def test_create_xml_retrieve_xml_round_trip(
-        self, client: TestClient, base_workitem_json: dict[str, Any]
-    ) -> None:
+    def test_create_xml_retrieve_xml_round_trip(self, client: TestClient, base_workitem_json: dict[str, Any]) -> None:
         """Contract: Workitem POSTed with XML body can be retrieved as XML with same patient data."""
         uid = _extract_sop_instance_uid_from_workitem(base_workitem_json)
         from pydicom.dataset import Dataset as PydcmDataset

--- a/tests/integration/transactions/test_dicom_xml_content_negotiation.py
+++ b/tests/integration/transactions/test_dicom_xml_content_negotiation.py
@@ -106,14 +106,21 @@ class TestGetWorkitemsXmlAccept:
     def test_get_workitems_xml_accept_body_is_valid_dicom_xml(
         self, client: TestClient, base_workitem_json: dict[str, Any]
     ) -> None:
-        """Contract: GET /workitems with XML Accept returns parseable DICOM XML."""
+        """Contract: GET /workitems with XML Accept returns multipart/related with parseable parts."""
         create_workitem_helper(client, base_workitem_json)
 
         resp = client.simulate_get("/workitems", headers={"Accept": "application/dicom+xml"})
 
         assert resp.status_code == 200
-        # Should be parseable as DICOM XML
-        ds = from_xml(resp.content)
+        ct = resp.headers.get("content-type", "")
+        assert "multipart/related" in ct
+        # Extract boundary and parse first part
+        boundary = ct.split("boundary=")[1]
+        parts = resp.content.split(f"--{boundary}".encode("utf-8"))
+        xml_parts = [p for p in parts[1:-1] if p.strip()]
+        assert len(xml_parts) >= 1
+        xml_body = xml_parts[0].split(b"\r\n\r\n", 1)[1].strip()
+        ds = from_xml(xml_body)
         assert isinstance(ds, Dataset)
 
     def test_get_workitems_json_accept_returns_json_content_type(
@@ -247,15 +254,22 @@ class TestRoundTripXmlJson:
         assert ds.PatientID == "XML-TEST-001"
 
     def test_create_json_retrieve_list_as_xml(self, client: TestClient, base_workitem_json: dict[str, Any]) -> None:
-        """Contract: Workitem list created with JSON can be retrieved as valid DICOM XML."""
+        """Contract: Workitem list created with JSON can be retrieved as multipart/related XML."""
         create_workitem_helper(client, base_workitem_json)
 
         resp = client.simulate_get("/workitems", headers={"Accept": "application/dicom+xml"})
 
         assert resp.status_code == 200
-        # The first XML document (before any newline separator) should be parseable
-        first_doc = resp.content.split(b"\n<?xml")[0]
-        ds = from_xml(first_doc)
+        assert "multipart/related" in resp.headers.get("content-type", "")
+        # Extract boundary and parse first part
+        ct = resp.headers["content-type"]
+        boundary = ct.split("boundary=")[1]
+        parts = resp.content.split(f"--{boundary}".encode("utf-8"))
+        xml_parts = [p for p in parts[1:-1] if p.strip()]
+        assert len(xml_parts) >= 1
+        # Parse the XML body from the first part (after headers)
+        xml_body = xml_parts[0].split(b"\r\n\r\n", 1)[1].strip()
+        ds = from_xml(xml_body)
         assert isinstance(ds, Dataset)
 
     def test_create_xml_retrieve_xml_round_trip(self, client: TestClient, base_workitem_json: dict[str, Any]) -> None:

--- a/tests/integration/transactions/test_dicom_xml_content_negotiation.py
+++ b/tests/integration/transactions/test_dicom_xml_content_negotiation.py
@@ -116,7 +116,7 @@ class TestGetWorkitemsXmlAccept:
         assert "multipart/related" in ct
         # Extract boundary and parse first part
         boundary = ct.split("boundary=")[1]
-        parts = resp.content.split(f"--{boundary}".encode("utf-8"))
+        parts = resp.content.split(f"--{boundary}".encode())
         xml_parts = [p for p in parts[1:-1] if p.strip()]
         assert len(xml_parts) >= 1
         xml_body = xml_parts[0].split(b"\r\n\r\n", 1)[1].strip()
@@ -264,7 +264,7 @@ class TestRoundTripXmlJson:
         # Extract boundary and parse first part
         ct = resp.headers["content-type"]
         boundary = ct.split("boundary=")[1]
-        parts = resp.content.split(f"--{boundary}".encode("utf-8"))
+        parts = resp.content.split(f"--{boundary}".encode())
         xml_parts = [p for p in parts[1:-1] if p.strip()]
         assert len(xml_parts) >= 1
         # Parse the XML body from the first part (after headers)

--- a/tests/integration/transactions/test_dicom_xml_content_negotiation.py
+++ b/tests/integration/transactions/test_dicom_xml_content_negotiation.py
@@ -276,3 +276,34 @@ class TestRoundTripXmlJson:
         assert resp.status_code == 200
         retrieved_ds = from_xml(resp.content)
         assert retrieved_ds.PatientID == "XML-TEST-001"
+
+
+class TestInvalidRequestBodyReturns400:
+    """Tests for invalid request bodies returning HTTP 400 instead of 500."""
+
+    def test_post_workitem_invalid_json_returns_400(self, client: TestClient) -> None:
+        """Contract: POST /workitems with malformed JSON body returns 400 Bad Request."""
+        resp = client.simulate_post(
+            "/workitems",
+            body=b"{not valid json}",
+            headers={"Content-Type": "application/dicom+json"},
+        )
+        assert resp.status_code == 400
+
+    def test_post_workitem_invalid_xml_returns_400(self, client: TestClient) -> None:
+        """Contract: POST /workitems with malformed XML body returns 400 Bad Request."""
+        resp = client.simulate_post(
+            "/workitems",
+            body=b"<unclosed-tag>this is not valid XML",
+            headers={"Content-Type": "application/dicom+xml"},
+        )
+        assert resp.status_code == 400
+
+    def test_post_workitem_truncated_json_returns_400(self, client: TestClient) -> None:
+        """Contract: POST /workitems with truncated JSON body returns 400 Bad Request."""
+        resp = client.simulate_post(
+            "/workitems",
+            body=b'{"00080018": {"vr": "UI"',  # truncated, no closing braces
+            headers={"Content-Type": "application/dicom+json"},
+        )
+        assert resp.status_code == 400

--- a/tests/unit/api/test_dicom_xml_support.py
+++ b/tests/unit/api/test_dicom_xml_support.py
@@ -255,7 +255,7 @@ class TestSerializeDatasetList:
         data, ct = serialize_dataset_list([simple_dataset], "application/dicom+xml")
         # Extract boundary from content type
         boundary = ct.split("boundary=")[1]
-        parts = data.split(f"--{boundary}".encode("utf-8"))
+        parts = data.split(f"--{boundary}".encode())
         # parts[0] is empty (before first boundary), parts[-1] is "--\r\n" (closing)
         xml_parts = [p for p in parts[1:-1] if p.strip()]
         assert len(xml_parts) == 1
@@ -277,7 +277,7 @@ class TestSerializeDatasetList:
         assert b"TEST-002" in data
         # Verify two parts
         boundary = ct.split("boundary=")[1]
-        parts = data.split(f"--{boundary}".encode("utf-8"))
+        parts = data.split(f"--{boundary}".encode())
         xml_parts = [p for p in parts[1:-1] if p.strip()]
         assert len(xml_parts) == 2
 

--- a/tests/unit/api/test_dicom_xml_support.py
+++ b/tests/unit/api/test_dicom_xml_support.py
@@ -10,8 +10,8 @@ Tests verify:
 """
 
 import json
-from typing import Any
-from unittest.mock import MagicMock
+from typing import TYPE_CHECKING, Any
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 from pydicom import Dataset
@@ -25,6 +25,9 @@ from pyupsrs.api.serializers.dicom_xml import (
     serialize_dataset,
     serialize_dataset_list,
 )
+
+if TYPE_CHECKING:
+    from pyupsrs.api.resources.workitems import DICOMJSONHandler
 
 # ---------------------------------------------------------------------------
 # Fixtures
@@ -159,7 +162,8 @@ class TestDICOMXMLHandler:
         stream.read.return_value = xml_bytes
         sync_result = xml_handler.deserialize(stream, "application/dicom+xml", len(xml_bytes))
 
-        stream2 = MagicMock()
+        # deserialize_async uses ``await stream.read()``, so stream must be an AsyncMock
+        stream2 = AsyncMock()
         stream2.read.return_value = xml_bytes
         async_result = await xml_handler.deserialize_async(stream2, "application/dicom+xml", len(xml_bytes))
 
@@ -329,3 +333,66 @@ class TestDeserializeRequestBody:
         xml_bytes = to_xml(simple_dataset)
         result = deserialize_request_body(xml_bytes, "application/dicom+xml; charset=utf-8")
         assert isinstance(result, Dataset)
+
+
+# ---------------------------------------------------------------------------
+# DICOMJSONHandler async deserialization (regression for issue #5)
+# ---------------------------------------------------------------------------
+
+
+class TestDICOMJSONHandlerAsync:
+    """Regression tests for DICOMJSONHandler async deserialization path."""
+
+    @pytest.fixture()
+    def json_handler(self) -> "DICOMJSONHandler":
+        """Return a fresh DICOMJSONHandler instance."""
+        from pyupsrs.api.resources.workitems import DICOMJSONHandler  # local import avoids circular import
+
+        return DICOMJSONHandler()
+
+    @pytest.mark.asyncio
+    async def test_deserialize_async_returns_dict_for_valid_json(self, json_handler: "DICOMJSONHandler") -> None:
+        """Contract: deserialize_async returns a dict for valid DICOM JSON body."""
+        payload: dict[str, Any] = {"00100020": {"vr": "LO", "Value": ["PATIENT-001"]}}
+        body = json.dumps(payload).encode()
+
+        # deserialize_async uses ``await stream.read()``, so stream must be an AsyncMock
+        stream = AsyncMock()
+        stream.read.return_value = body
+
+        result = await json_handler.deserialize_async(stream, "application/dicom+json", len(body))
+
+        assert isinstance(result, dict)
+        assert "00100020" in result
+        assert result["00100020"]["Value"] == ["PATIENT-001"]
+
+    @pytest.mark.asyncio
+    async def test_deserialize_async_returns_empty_dict_for_empty_body(self, json_handler: "DICOMJSONHandler") -> None:
+        """Contract: deserialize_async returns empty dict when body is empty."""
+        stream = AsyncMock()
+        stream.read.return_value = b""
+
+        result = await json_handler.deserialize_async(stream, "application/dicom+json", 0)
+
+        assert result == {}
+
+    @pytest.mark.asyncio
+    async def test_deserialize_async_matches_sync_result(self, json_handler: "DICOMJSONHandler") -> None:
+        """Contract: async deserialize produces the same dict as sync deserialize."""
+        payload: dict[str, Any] = {
+            "00080016": {"vr": "UI", "Value": ["1.2.840.10008.5.1.4.34.6.1"]},
+            "00100020": {"vr": "LO", "Value": ["SYNC-ASYNC-MATCH"]},
+        }
+        body = json.dumps(payload).encode()
+
+        # Sync path
+        sync_stream = MagicMock()
+        sync_stream.read.return_value = body
+        sync_result = json_handler.deserialize(sync_stream, "application/dicom+json", len(body))
+
+        # Async path (uses await stream.read())
+        async_stream = AsyncMock()
+        async_stream.read.return_value = body
+        async_result = await json_handler.deserialize_async(async_stream, "application/dicom+json", len(body))
+
+        assert sync_result == async_result

--- a/tests/unit/api/test_dicom_xml_support.py
+++ b/tests/unit/api/test_dicom_xml_support.py
@@ -1,0 +1,331 @@
+"""
+Unit tests for DICOM XML support in workitems resources.
+
+Tests verify:
+- Content negotiation selects correct media type from Accept header
+- DICOMXMLHandler serializes/deserializes Datasets correctly
+- serialize_dataset and serialize_dataset_list produce correct output per content type
+- deserialize_request_body handles both JSON and XML content types
+- Round-trips: JSON to XML and XML to JSON are consistent
+"""
+
+import json
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+from pydicom import Dataset
+from pydicom_xml import from_xml, to_xml
+
+from pyupsrs.api.serializers.dicom_xml import (
+    SUPPORTED_DICOM_MEDIA_TYPES,
+    DICOMXMLHandler,
+    deserialize_request_body,
+    negotiate_content_type,
+    serialize_dataset,
+    serialize_dataset_list,
+)
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def simple_dataset() -> Dataset:
+    """Return a minimal pydicom Dataset with a few attributes."""
+    ds = Dataset()
+    ds.file_meta = Dataset()
+    ds.PatientName = "Test^Patient"
+    ds.PatientID = "TEST-001"
+    ds.is_implicit_VR = False
+    ds.is_little_endian = True
+    return ds
+
+
+@pytest.fixture()
+def xml_handler() -> DICOMXMLHandler:
+    """Return a fresh DICOMXMLHandler instance."""
+    return DICOMXMLHandler()
+
+
+def _make_accept_request(accept: str) -> MagicMock:
+    """Build a minimal Falcon Request mock that responds to client_prefers."""
+    req = MagicMock()
+
+    def _client_prefers(types: list[str]) -> str | None:
+        for offered in types:
+            if offered in accept:
+                return offered
+        return None
+
+    req.client_prefers.side_effect = _client_prefers
+    return req
+
+
+# ---------------------------------------------------------------------------
+# negotiate_content_type
+# ---------------------------------------------------------------------------
+
+
+class TestNegotiateContentType:
+    """Tests for negotiate_content_type helper."""
+
+    def test_json_accept_returns_json(self) -> None:
+        """Contract: Accept application/dicom+json returns JSON content type."""
+        req = _make_accept_request("application/dicom+json")
+        result = negotiate_content_type(req)
+        assert result == "application/dicom+json"
+
+    def test_xml_accept_returns_xml(self) -> None:
+        """Contract: Accept application/dicom+xml returns XML content type."""
+        req = _make_accept_request("application/dicom+xml")
+        result = negotiate_content_type(req)
+        assert result == "application/dicom+xml"
+
+    def test_no_accept_defaults_to_json(self) -> None:
+        """Contract: Missing or unsupported Accept header defaults to JSON."""
+        req = MagicMock()
+        req.client_prefers.return_value = None
+        result = negotiate_content_type(req)
+        assert result == "application/dicom+json"
+
+    def test_unsupported_accept_defaults_to_json(self) -> None:
+        """Contract: An unsupported Accept media type defaults to JSON."""
+        req = _make_accept_request("text/html")
+        result = negotiate_content_type(req)
+        assert result == "application/dicom+json"
+
+    def test_supported_media_types_constant(self) -> None:
+        """Contract: SUPPORTED_DICOM_MEDIA_TYPES includes both JSON and XML."""
+        assert "application/dicom+json" in SUPPORTED_DICOM_MEDIA_TYPES
+        assert "application/dicom+xml" in SUPPORTED_DICOM_MEDIA_TYPES
+
+
+# ---------------------------------------------------------------------------
+# DICOMXMLHandler
+# ---------------------------------------------------------------------------
+
+
+class TestDICOMXMLHandler:
+    """Tests for DICOMXMLHandler serialization and deserialization."""
+
+    def test_serialize_dataset_returns_bytes(self, xml_handler: DICOMXMLHandler, simple_dataset: Dataset) -> None:
+        """Contract: serialize returns bytes for a Dataset."""
+        result = xml_handler.serialize(simple_dataset, "application/dicom+xml")
+        assert isinstance(result, bytes)
+
+    def test_serialize_dataset_is_valid_xml(self, xml_handler: DICOMXMLHandler, simple_dataset: Dataset) -> None:
+        """Contract: serialized bytes are parseable as DICOM XML."""
+        xml_bytes = xml_handler.serialize(simple_dataset, "application/dicom+xml")
+        # If this doesn't raise, the XML is valid DICOM XML
+        recovered = from_xml(xml_bytes)
+        assert isinstance(recovered, Dataset)
+
+    def test_serialize_bytes_passthrough(self, xml_handler: DICOMXMLHandler) -> None:
+        """Contract: serialize passes pre-serialized bytes through unchanged."""
+        raw = b"<NativeDicomModel/>"
+        result = xml_handler.serialize(raw, "application/dicom+xml")
+        assert result is raw
+
+    def test_deserialize_returns_dataset(self, xml_handler: DICOMXMLHandler, simple_dataset: Dataset) -> None:
+        """Contract: deserialize returns a Dataset from valid XML bytes."""
+        xml_bytes = to_xml(simple_dataset)
+        stream = MagicMock()
+        stream.read.return_value = xml_bytes
+        result = xml_handler.deserialize(stream, "application/dicom+xml", len(xml_bytes))
+        assert isinstance(result, Dataset)
+
+    def test_deserialize_preserves_patient_name(self, xml_handler: DICOMXMLHandler, simple_dataset: Dataset) -> None:
+        """Contract: deserialize round-trip preserves PatientName attribute."""
+        xml_bytes = to_xml(simple_dataset)
+        stream = MagicMock()
+        stream.read.return_value = xml_bytes
+        result = xml_handler.deserialize(stream, "application/dicom+xml", len(xml_bytes))
+        assert str(result.PatientName) == "Test^Patient"
+
+    def test_deserialize_empty_body_returns_empty_dataset(self, xml_handler: DICOMXMLHandler) -> None:
+        """Contract: deserialize with empty body returns an empty Dataset."""
+        stream = MagicMock()
+        stream.read.return_value = b""
+        result = xml_handler.deserialize(stream, "application/dicom+xml", 0)
+        assert isinstance(result, Dataset)
+
+    @pytest.mark.asyncio
+    async def test_deserialize_async_matches_sync(self, xml_handler: DICOMXMLHandler, simple_dataset: Dataset) -> None:
+        """Contract: async deserialize returns same result as sync."""
+        xml_bytes = to_xml(simple_dataset)
+        stream = MagicMock()
+        stream.read.return_value = xml_bytes
+        sync_result = xml_handler.deserialize(stream, "application/dicom+xml", len(xml_bytes))
+
+        stream2 = MagicMock()
+        stream2.read.return_value = xml_bytes
+        async_result = await xml_handler.deserialize_async(stream2, "application/dicom+xml", len(xml_bytes))
+
+        assert str(sync_result.PatientName) == str(async_result.PatientName)
+
+    @pytest.mark.asyncio
+    async def test_serialize_async_matches_sync(self, xml_handler: DICOMXMLHandler, simple_dataset: Dataset) -> None:
+        """Contract: async serialize returns same bytes as sync."""
+        sync_result = xml_handler.serialize(simple_dataset, "application/dicom+xml")
+        async_result = await xml_handler.serialize_async(simple_dataset, "application/dicom+xml")
+        assert sync_result == async_result
+
+
+# ---------------------------------------------------------------------------
+# serialize_dataset
+# ---------------------------------------------------------------------------
+
+
+class TestSerializeDataset:
+    """Tests for serialize_dataset helper."""
+
+    def test_json_content_type_returns_str(self, simple_dataset: Dataset) -> None:
+        """Contract: JSON content type returns a string."""
+        data, ct = serialize_dataset(simple_dataset, "application/dicom+json")
+        assert isinstance(data, str)
+        assert ct == "application/dicom+json"
+
+    def test_json_result_is_valid_json(self, simple_dataset: Dataset) -> None:
+        """Contract: JSON result is parseable JSON."""
+        data, _ = serialize_dataset(simple_dataset, "application/dicom+json")
+        parsed = json.loads(data)
+        assert isinstance(parsed, dict)
+
+    def test_xml_content_type_returns_bytes(self, simple_dataset: Dataset) -> None:
+        """Contract: XML content type returns bytes."""
+        data, ct = serialize_dataset(simple_dataset, "application/dicom+xml")
+        assert isinstance(data, bytes)
+        assert ct == "application/dicom+xml"
+
+    def test_xml_result_is_valid_dicom_xml(self, simple_dataset: Dataset) -> None:
+        """Contract: XML result is parseable as DICOM XML."""
+        data, _ = serialize_dataset(simple_dataset, "application/dicom+xml")
+        recovered = from_xml(data)
+        assert isinstance(recovered, Dataset)
+
+    def test_xml_preserves_patient_id(self, simple_dataset: Dataset) -> None:
+        """Contract: XML serialization preserves PatientID attribute."""
+        data, _ = serialize_dataset(simple_dataset, "application/dicom+xml")
+        recovered = from_xml(data)
+        assert recovered.PatientID == "TEST-001"
+
+
+# ---------------------------------------------------------------------------
+# serialize_dataset_list
+# ---------------------------------------------------------------------------
+
+
+class TestSerializeDatasetList:
+    """Tests for serialize_dataset_list helper."""
+
+    def test_json_single_dataset_is_array(self, simple_dataset: Dataset) -> None:
+        """Contract: JSON list serialization wraps single dataset in JSON array."""
+        data, ct = serialize_dataset_list([simple_dataset], "application/dicom+json")
+        assert ct == "application/dicom+json"
+        parsed = json.loads(data)
+        assert isinstance(parsed, list)
+        assert len(parsed) == 1
+
+    def test_json_multiple_datasets_is_array(self, simple_dataset: Dataset) -> None:
+        """Contract: JSON list serialization wraps multiple datasets in JSON array."""
+        ds2 = Dataset()
+        ds2.PatientName = "Second^Patient"
+        ds2.PatientID = "TEST-002"
+        ds2.is_implicit_VR = False
+        ds2.is_little_endian = True
+        data, ct = serialize_dataset_list([simple_dataset, ds2], "application/dicom+json")
+        parsed = json.loads(data)
+        assert len(parsed) == 2
+
+    def test_xml_single_dataset_returns_bytes(self, simple_dataset: Dataset) -> None:
+        """Contract: XML list serialization returns bytes."""
+        data, ct = serialize_dataset_list([simple_dataset], "application/dicom+xml")
+        assert ct == "application/dicom+xml"
+        assert isinstance(data, bytes)
+
+    def test_xml_single_dataset_is_valid_dicom_xml(self, simple_dataset: Dataset) -> None:
+        """Contract: XML list result is parseable as DICOM XML."""
+        data, _ = serialize_dataset_list([simple_dataset], "application/dicom+xml")
+        # Single dataset → single XML document, parseable by from_xml
+        recovered = from_xml(data)
+        assert isinstance(recovered, Dataset)
+
+    def test_xml_multiple_datasets_contains_all_patient_ids(self, simple_dataset: Dataset) -> None:
+        """Contract: XML list of multiple datasets contains data from all datasets."""
+        ds2 = Dataset()
+        ds2.PatientName = "Second^Patient"
+        ds2.PatientID = "TEST-002"
+        ds2.is_implicit_VR = False
+        ds2.is_little_endian = True
+        data, _ = serialize_dataset_list([simple_dataset, ds2], "application/dicom+xml")
+        # Both patient IDs should appear in the concatenated output
+        assert b"TEST-001" in data
+        assert b"TEST-002" in data
+
+    def test_empty_list_json(self) -> None:
+        """Contract: Empty list produces empty JSON array."""
+        data, ct = serialize_dataset_list([], "application/dicom+json")
+        assert ct == "application/dicom+json"
+        parsed = json.loads(data)
+        assert parsed == []
+
+    def test_empty_list_xml(self) -> None:
+        """Contract: Empty list produces empty bytes for XML."""
+        data, ct = serialize_dataset_list([], "application/dicom+xml")
+        assert ct == "application/dicom+xml"
+        assert data == b""
+
+
+# ---------------------------------------------------------------------------
+# deserialize_request_body
+# ---------------------------------------------------------------------------
+
+
+class TestDeserializeRequestBody:
+    """Tests for deserialize_request_body helper."""
+
+    def test_json_content_type_returns_dict(self) -> None:
+        """Contract: JSON content type returns a dict."""
+        payload: dict[str, Any] = {"00100020": {"vr": "LO", "Value": ["TEST-001"]}}
+        body = json.dumps(payload).encode()
+        result = deserialize_request_body(body, "application/dicom+json")
+        assert isinstance(result, dict)
+        assert "00100020" in result
+
+    def test_xml_content_type_returns_dataset(self, simple_dataset: Dataset) -> None:
+        """Contract: XML content type returns a Dataset."""
+        xml_bytes = to_xml(simple_dataset)
+        result = deserialize_request_body(xml_bytes, "application/dicom+xml")
+        assert isinstance(result, Dataset)
+
+    def test_xml_content_type_preserves_patient_id(self, simple_dataset: Dataset) -> None:
+        """Contract: XML deserialization preserves PatientID."""
+        xml_bytes = to_xml(simple_dataset)
+        result = deserialize_request_body(xml_bytes, "application/dicom+xml")
+        assert isinstance(result, Dataset)
+        assert result.PatientID == "TEST-001"
+
+    def test_none_content_type_parses_as_json(self) -> None:
+        """Contract: None content type falls back to JSON parsing."""
+        payload: dict[str, Any] = {"00100020": {"vr": "LO", "Value": ["TEST-001"]}}
+        body = json.dumps(payload).encode()
+        result = deserialize_request_body(body, None)
+        assert isinstance(result, dict)
+
+    def test_empty_body_json_returns_empty_dict(self) -> None:
+        """Contract: Empty body with JSON content type returns empty dict."""
+        result = deserialize_request_body(b"", "application/dicom+json")
+        assert result == {}
+
+    def test_empty_body_xml_returns_empty_dataset(self) -> None:
+        """Contract: Empty body with XML content type returns empty Dataset."""
+        result = deserialize_request_body(b"", "application/dicom+xml")
+        assert isinstance(result, Dataset)
+
+    def test_xml_content_type_with_charset_suffix(self, simple_dataset: Dataset) -> None:
+        """Contract: application/dicom+xml with charset suffix is recognized as XML."""
+        xml_bytes = to_xml(simple_dataset)
+        result = deserialize_request_body(xml_bytes, "application/dicom+xml; charset=utf-8")
+        assert isinstance(result, Dataset)

--- a/tests/unit/api/test_dicom_xml_support.py
+++ b/tests/unit/api/test_dicom_xml_support.py
@@ -243,30 +243,43 @@ class TestSerializeDatasetList:
         parsed = json.loads(data)
         assert len(parsed) == 2
 
-    def test_xml_single_dataset_returns_bytes(self, simple_dataset: Dataset) -> None:
-        """Contract: XML list serialization returns bytes."""
+    def test_xml_single_dataset_returns_multipart(self, simple_dataset: Dataset) -> None:
+        """Contract: XML list serialization returns multipart/related bytes."""
         data, ct = serialize_dataset_list([simple_dataset], "application/dicom+xml")
-        assert ct == "application/dicom+xml"
+        assert "multipart/related" in ct
+        assert "boundary=" in ct
         assert isinstance(data, bytes)
 
-    def test_xml_single_dataset_is_valid_dicom_xml(self, simple_dataset: Dataset) -> None:
-        """Contract: XML list result is parseable as DICOM XML."""
-        data, _ = serialize_dataset_list([simple_dataset], "application/dicom+xml")
-        # Single dataset → single XML document, parseable by from_xml
-        recovered = from_xml(data)
+    def test_xml_single_dataset_part_is_valid_dicom_xml(self, simple_dataset: Dataset) -> None:
+        """Contract: each part in XML multipart response is parseable as DICOM XML."""
+        data, ct = serialize_dataset_list([simple_dataset], "application/dicom+xml")
+        # Extract boundary from content type
+        boundary = ct.split("boundary=")[1]
+        parts = data.split(f"--{boundary}".encode("utf-8"))
+        # parts[0] is empty (before first boundary), parts[-1] is "--\r\n" (closing)
+        xml_parts = [p for p in parts[1:-1] if p.strip()]
+        assert len(xml_parts) == 1
+        # Extract XML body after the headers (double CRLF)
+        xml_body = xml_parts[0].split(b"\r\n\r\n", 1)[1].strip()
+        recovered = from_xml(xml_body)
         assert isinstance(recovered, Dataset)
 
-    def test_xml_multiple_datasets_contains_all_patient_ids(self, simple_dataset: Dataset) -> None:
-        """Contract: XML list of multiple datasets contains data from all datasets."""
+    def test_xml_multiple_datasets_multipart_contains_all(self, simple_dataset: Dataset) -> None:
+        """Contract: XML multipart response contains all datasets as separate parts."""
         ds2 = Dataset()
         ds2.PatientName = "Second^Patient"
         ds2.PatientID = "TEST-002"
         ds2.is_implicit_VR = False
         ds2.is_little_endian = True
-        data, _ = serialize_dataset_list([simple_dataset, ds2], "application/dicom+xml")
-        # Both patient IDs should appear in the concatenated output
+        data, ct = serialize_dataset_list([simple_dataset, ds2], "application/dicom+xml")
+        assert "multipart/related" in ct
         assert b"TEST-001" in data
         assert b"TEST-002" in data
+        # Verify two parts
+        boundary = ct.split("boundary=")[1]
+        parts = data.split(f"--{boundary}".encode("utf-8"))
+        xml_parts = [p for p in parts[1:-1] if p.strip()]
+        assert len(xml_parts) == 2
 
     def test_empty_list_json(self) -> None:
         """Contract: Empty list produces empty JSON array."""

--- a/uv.lock
+++ b/uv.lock
@@ -487,11 +487,19 @@ wheels = [
 
 [[package]]
 name = "pydicom"
-version = "3.0.1"
+version = "3.0.2"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/d7/6f/55ea163b344c91df2e03c007bebf94781f0817656e2c037d7c5bf86c3bfc/pydicom-3.0.1.tar.gz", hash = "sha256:7b8be344b5b62493c9452ba6f5a299f78f8a6ab79786c729b0613698209603ec", size = 2884731 }
+sdist = { url = "https://files.pythonhosted.org/packages/7a/de/52aaf905f1f0ae7aba85996e2592ea2c1fe49157f3cfbcd1871965bdb51d/pydicom-3.0.2.tar.gz", hash = "sha256:5942bfc2d72c6fa4b3b5b62c527f54b7f2355f21d6f5d296df6bb30188df6a4f", size = 2886792 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/27/a6/98651e752a49f341aa99aa3f6c8ba361728dfc064242884355419df63669/pydicom-3.0.1-py3-none-any.whl", hash = "sha256:db32f78b2641bd7972096b8289111ddab01fb221610de8d7afa835eb938adb41", size = 2376126 },
+    { url = "https://files.pythonhosted.org/packages/46/e0/60466c6d712dad2cf807df315e39863e91609ffd1064ecb835994460bbda/pydicom-3.0.2-py3-none-any.whl", hash = "sha256:abf971a5440f84dbaf42c4b6758e30e62480902584f8b270b9a5d146e278a07b", size = 2376822 },
+]
+
+[[package]]
+name = "pydicom-xml"
+version = "0.1.0"
+source = { git = "https://github.com/sjswerdloff/pydicom-xml#02244d9f66097aff36bcbbc51c51a13997dfb7cd" }
+dependencies = [
+    { name = "pydicom" },
 ]
 
 [[package]]
@@ -573,6 +581,7 @@ dependencies = [
     { name = "falcon" },
     { name = "httpx" },
     { name = "pydicom" },
+    { name = "pydicom-xml" },
     { name = "uvicorn" },
     { name = "websockets" },
 ]
@@ -610,6 +619,7 @@ requires-dist = [
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.9.0" },
     { name = "pre-commit", marker = "extra == 'dev'", specifier = ">=4.2.0" },
     { name = "pydicom", specifier = ">=3.0.1" },
+    { name = "pydicom-xml", git = "https://github.com/sjswerdloff/pydicom-xml" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.3.5" },
     { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=0.26.0" },
     { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=6.1.1" },

--- a/uv.lock
+++ b/uv.lock
@@ -497,7 +497,7 @@ wheels = [
 [[package]]
 name = "pydicom-xml"
 version = "0.1.0"
-source = { git = "https://github.com/sjswerdloff/pydicom-xml#02244d9f66097aff36bcbbc51c51a13997dfb7cd" }
+source = { git = "https://github.com/sjswerdloff/pydicom-xml?rev=02244d9f66097aff36bcbbc51c51a13997dfb7cd#02244d9f66097aff36bcbbc51c51a13997dfb7cd" }
 dependencies = [
     { name = "pydicom" },
 ]
@@ -574,6 +574,31 @@ wheels = [
 ]
 
 [[package]]
+name = "pytest-json-report"
+version = "1.5.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pytest" },
+    { name = "pytest-metadata" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/4f/d3/765dae9712fcd68d820338908c1337e077d5fdadccd5cacf95b9b0bea278/pytest-json-report-1.5.0.tar.gz", hash = "sha256:2dde3c647851a19b5f3700729e8310a6e66efb2077d674f27ddea3d34dc615de", size = 21241 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/81/35/d07400c715bf8a88aa0c1ee9c9eb6050ca7fe5b39981f0eea773feeb0681/pytest_json_report-1.5.0-py3-none-any.whl", hash = "sha256:9897b68c910b12a2e48dd849f9a284b2c79a732a8a9cb398452ddd23d3c8c325", size = 13222 },
+]
+
+[[package]]
+name = "pytest-metadata"
+version = "3.1.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a6/85/8c969f8bec4e559f8f2b958a15229a35495f5b4ce499f6b865eac54b878d/pytest_metadata-3.1.1.tar.gz", hash = "sha256:d2a29b0355fbc03f168aa96d41ff88b1a3b44a3b02acbe491801c98a048017c8", size = 9952 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3e/43/7e7b2ec865caa92f67b8f0e9231a798d102724ca4c0e1f414316be1c1ef2/pytest_metadata-3.1.1-py3-none-any.whl", hash = "sha256:c8e0844db684ee1c798cfa38908d20d67d0463ecb6137c72e91f418558dd5f4b", size = 11428 },
+]
+
+[[package]]
 name = "pyupsrs"
 version = "0.1.0"
 source = { editable = "." }
@@ -608,6 +633,7 @@ dev = [
     { name = "pre-commit" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
+    { name = "pytest-json-report" },
     { name = "ruff" },
 ]
 
@@ -619,7 +645,7 @@ requires-dist = [
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.9.0" },
     { name = "pre-commit", marker = "extra == 'dev'", specifier = ">=4.2.0" },
     { name = "pydicom", specifier = ">=3.0.1" },
-    { name = "pydicom-xml", git = "https://github.com/sjswerdloff/pydicom-xml" },
+    { name = "pydicom-xml", git = "https://github.com/sjswerdloff/pydicom-xml?rev=02244d9f66097aff36bcbbc51c51a13997dfb7cd" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.3.5" },
     { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=0.26.0" },
     { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=6.1.1" },
@@ -638,6 +664,7 @@ dev = [
     { name = "pre-commit", specifier = ">=4.2.0" },
     { name = "pytest", specifier = ">=8.3.5" },
     { name = "pytest-asyncio", specifier = ">=0.26.0" },
+    { name = "pytest-json-report", specifier = ">=1.5.0" },
     { name = "ruff", specifier = ">=0.11.8" },
 ]
 

--- a/uv.lock
+++ b/uv.lock
@@ -497,7 +497,7 @@ wheels = [
 [[package]]
 name = "pydicom-xml"
 version = "0.1.0"
-source = { git = "https://github.com/sjswerdloff/pydicom-xml?rev=02244d9f66097aff36bcbbc51c51a13997dfb7cd#02244d9f66097aff36bcbbc51c51a13997dfb7cd" }
+source = { git = "https://github.com/sjswerdloff/pydicom-xml?rev=266cda9#266cda95990130c85794c86baabc723c1c10502d" }
 dependencies = [
     { name = "pydicom" },
 ]
@@ -645,7 +645,7 @@ requires-dist = [
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.9.0" },
     { name = "pre-commit", marker = "extra == 'dev'", specifier = ">=4.2.0" },
     { name = "pydicom", specifier = ">=3.0.1" },
-    { name = "pydicom-xml", git = "https://github.com/sjswerdloff/pydicom-xml?rev=02244d9f66097aff36bcbbc51c51a13997dfb7cd" },
+    { name = "pydicom-xml", git = "https://github.com/sjswerdloff/pydicom-xml?rev=266cda9" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.3.5" },
     { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=0.26.0" },
     { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=6.1.1" },


### PR DESCRIPTION
## Summary

- Adds `application/dicom+xml` (Native DICOM Model, PS3.19) support alongside the existing `application/dicom+json`, satisfying the DICOMWeb PS3.18 Table 8.7.3-3 requirement that servers support both media types
- New `pyupsrs/api/serializers/dicom_xml.py` module containing `DICOMXMLHandler`, `negotiate_content_type`, `serialize_dataset`, `serialize_dataset_list`, and `deserialize_request_body` helpers — kept in serializers to avoid the existing circular import in the resources layer
- Content negotiation via `req.client_prefers()` on all GET endpoints; defaults to `application/dicom+json` when no Accept header or unrecognized type
- POST endpoints parse XML request bodies directly to a `Dataset`, bypassing the JSON `deserialize_workitem` path
- Fixes a pre-existing bug: `DICOMJSONHandler.deserialize_async` was calling `self.deserialize()` with no arguments

## Test plan

- [x] 32 unit tests covering all serializer contracts: `DICOMXMLHandler`, `negotiate_content_type`, `serialize_dataset`, `serialize_dataset_list`, `deserialize_request_body`
- [x] 13 integration tests covering end-to-end HTTP flows via Falcon `TestClient`:
  - GET /workitems with `Accept: application/dicom+xml` → XML content type, valid DICOM XML body
  - GET /workitems with `Accept: application/dicom+json` → JSON (existing behavior preserved)
  - GET /workitems with no Accept header → JSON default
  - GET /workitems/{uid} with XML Accept → XML response parseable by `from_xml()`
  - POST /workitems with `Content-Type: application/dicom+xml` → 201, workitem retrievable
  - Round-trip: create with JSON, retrieve with XML Accept; create with XML, retrieve with XML
- [x] All 74 tests pass (29 pre-existing + 45 new)
- [x] Zero ruff linting violations
- [x] Zero mypy type errors

## Dependency

`pydicom-xml` installed from `git+https://github.com/sjswerdloff/pydicom-xml` (not yet on PyPI).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Add DICOM XML (application/dicom+xml) support across UPS-RS workitem endpoints with proper content negotiation and robust request/response handling.

New Features:
- Support application/dicom+xml alongside application/dicom+json for workitem request and response payloads, including multipart XML responses for dataset lists.
- Introduce a DICOM XML serializer module providing handlers and helpers for negotiating, serializing, and deserializing DICOM datasets in XML.

Bug Fixes:
- Fix asynchronous DICOM JSON request deserialization to correctly read the request body stream and return parsed JSON instead of calling the sync path incorrectly.
- Ensure malformed JSON or XML request bodies result in HTTP 400 responses instead of generic server errors.

Enhancements:
- Implement content negotiation based on the Accept header for workitem endpoints, defaulting to DICOM JSON when no supported type is requested.
- Unify dataset and dataset-list serialization helpers to return either JSON strings or XML bytes and set the appropriate response content type, with clearer error handling on serialization failures.

Build:
- Add the pydicom-xml dependency sourced from Git for DICOM XML support and include pytest-json-report in dev dependencies.

Tests:
- Add comprehensive unit tests for DICOM XML serialization helpers, content negotiation, and request body deserialization logic, including JSON/XML round-trips and async paths.
- Add integration tests covering DICOM XML content negotiation, XML POST bodies, round-trip JSON↔XML behavior, and 400 responses for malformed payloads.