### PR TITLE
fix: remove deprecated is_implicit_VR and is_little_endian from tests

### DIFF
--- a/tests/unit/api/test_dicom_xml_support.py
+++ b/tests/unit/api/test_dicom_xml_support.py
@@ -41,8 +41,6 @@ def simple_dataset() -> Dataset:
     ds.file_meta = Dataset()
     ds.PatientName = "Test^Patient"
     ds.PatientID = "TEST-001"
-    ds.is_implicit_VR = False
-    ds.is_little_endian = True
     return ds
 
 
@@ -237,8 +235,6 @@ class TestSerializeDatasetList:
         ds2 = Dataset()
         ds2.PatientName = "Second^Patient"
         ds2.PatientID = "TEST-002"
-        ds2.is_implicit_VR = False
-        ds2.is_little_endian = True
         data, ct = serialize_dataset_list([simple_dataset, ds2], "application/dicom+json")
         parsed = json.loads(data)
         assert len(parsed) == 2
@@ -269,8 +265,6 @@ class TestSerializeDatasetList:
         ds2 = Dataset()
         ds2.PatientName = "Second^Patient"
         ds2.PatientID = "TEST-002"
-        ds2.is_implicit_VR = False
-        ds2.is_little_endian = True
         data, ct = serialize_dataset_list([simple_dataset, ds2], "application/dicom+xml")
         assert "multipart/related" in ct
         assert b"TEST-001" in data


### PR DESCRIPTION
## Summary

- Remove deprecated `ds.is_implicit_VR = False` and `ds.is_little_endian = True` assignments from test fixtures
- These attributes are not needed for in-memory Dataset serialization (XML/JSON)
- Eliminates 42 `DeprecationWarning` messages from pydicom 3.x
- Prepares for pydicom 4.0 where these become hard errors

## Test plan

- [x] All 50 unit tests pass
- [x] Tests pass with `-W error::DeprecationWarning` (zero warnings)
- [x] Lint clean
- [ ] sourcery-ai review

Closes #10

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Remove deprecated pydicom dataset endianness and VR attribute assignments from XML/JSON serialization tests to avoid deprecation warnings and prepare for future pydicom versions.

Bug Fixes:
- Eliminate use of deprecated is_implicit_VR and is_little_endian attributes in test fixtures that triggered DeprecationWarning under pydicom 3.x.

Tests:
- Simplify DICOM XML/JSON serialization tests by relying on default in-memory dataset settings instead of explicitly setting deprecated attributes.