### PR TITLE
chore: update pydicom-xml to 06032da

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -108,7 +108,7 @@ disallow_untyped_defs = false
 disallow_incomplete_defs = false
 
 [tool.uv.sources]
-pydicom-xml = { git = "https://github.com/sjswerdloff/pydicom-xml", rev = "266cda9" }
+pydicom-xml = { git = "https://github.com/sjswerdloff/pydicom-xml", rev = "06032da" }
 
 [dependency-groups]
 dev = [

--- a/uv.lock
+++ b/uv.lock
@@ -497,7 +497,7 @@ wheels = [
 [[package]]
 name = "pydicom-xml"
 version = "0.1.0"
-source = { git = "https://github.com/sjswerdloff/pydicom-xml?rev=266cda9#266cda95990130c85794c86baabc723c1c10502d" }
+source = { git = "https://github.com/sjswerdloff/pydicom-xml?rev=06032da#06032da7b7ef146fdd54a4dcac0f32bd417cac82" }
 dependencies = [
     { name = "pydicom" },
 ]
@@ -645,7 +645,7 @@ requires-dist = [
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.9.0" },
     { name = "pre-commit", marker = "extra == 'dev'", specifier = ">=4.2.0" },
     { name = "pydicom", specifier = ">=3.0.1" },
-    { name = "pydicom-xml", git = "https://github.com/sjswerdloff/pydicom-xml?rev=266cda9" },
+    { name = "pydicom-xml", git = "https://github.com/sjswerdloff/pydicom-xml?rev=06032da" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.3.5" },
     { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=0.26.0" },
     { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=6.1.1" },


### PR DESCRIPTION
## Summary

- Update pydicom-xml dependency to latest main (06032da)
- Picks up PR #9: RFC 2046 boundary validation and per-part Content-Type checking

## Test plan

- [x] `uv sync` resolves new rev
- [x] All 50 unit tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Build:
- Bump the pydicom-xml git dependency reference from commit 266cda9 to 06032da in pyproject configuration.