### PR TITLE
fix: three bugs in dicom_utils and cancel_workitem

### DIFF
--- a/pyupsrs/domain/services/workitem_service.py
+++ b/pyupsrs/domain/services/workitem_service.py
@@ -108,24 +108,15 @@ class WorkItemService(LoggerMixin):
             raise e
         return updated_workitem, True
 
-    def cancel_workitem(self, workitem: WorkItem) -> WorkItem:
+    def cancel_workitem(self, workitem: WorkItem) -> tuple[WorkItem, bool]:
         """
-        Create a new workitem.
+        Cancel a workitem by transitioning it to CANCELED state.
 
         Args:
-            workitem: The workitem to create.
+            workitem: The workitem to cancel.
 
         Returns:
-            The created workitem.
+            A tuple of (updated workitem, success).
 
         """
-        # Save to repository
-        created_workitem = self.workitem_repository.create(workitem)
-
-        # Send notification
-        if self.notification_service:
-            self.notification_service.notify_creation(created_workitem)
-        else:
-            self.logger.warning("Notification Service not injected, no notifications will be sent")
-
-        return created_workitem
+        return self.update_workitem_status(workitem.uid, WorkItemStatus.CANCELED, transaction_uid=workitem.transaction_uid)

--- a/pyupsrs/utils/dicom_utils.py
+++ b/pyupsrs/utils/dicom_utils.py
@@ -18,18 +18,18 @@ def generate_uid() -> str:
     return uid.generate_uid()
 
 
-def validate_uid(uid: str) -> bool:
+def validate_uid(dicom_uid: str) -> bool:
     """
     Validate a DICOM UID.
 
     Args:
-        uid: The UID to validate.
+        dicom_uid: The UID to validate.
 
     Returns:
         True if valid, False otherwise.
 
     """
-    return uid.UID(uid).is_valid
+    return uid.UID(dicom_uid).is_valid
 
 
 def to_dicom_date_str(date: datetime, vr: valuerep.VR = valuerep.VR.DA) -> str:
@@ -44,4 +44,4 @@ def to_dicom_date_str(date: datetime, vr: valuerep.VR = valuerep.VR.DA) -> str:
         str: The string representation for the specified date/time VR.
 
     """
-    return date.strftime(VR_STRFTIME.get(vr, default=valuerep.VR.DA))
+    return date.strftime(VR_STRFTIME.get(vr, VR_STRFTIME[valuerep.VR.DA]))

--- a/pyupsrs/utils/dicom_utils.py
+++ b/pyupsrs/utils/dicom_utils.py
@@ -44,4 +44,4 @@ def to_dicom_date_str(date: datetime, vr: valuerep.VR = valuerep.VR.DA) -> str:
         str: The string representation for the specified date/time VR.
 
     """
-    return date.strftime(VR_STRFTIME.get(vr, VR_STRFTIME[valuerep.VR.DA]))
+    return date.strftime(VR_STRFTIME.get(vr, "%Y%m%d"))


### PR DESCRIPTION
## Summary
- **validate_uid**: parameter `uid` shadowed the imported `uid` module, making `uid.UID(uid)` call `.UID()` on a string — would crash at runtime
- **to_dicom_date_str**: `dict.get(vr, default=valuerep.VR.DA)` raises `TypeError` (`default` is positional-only); fallback also fixed to resolve to DA format string instead of VR enum
- **cancel_workitem**: was a complete copy-paste of `create_workitem()` — wrong docstring, called `create`/`notify_creation` instead of canceling. Now delegates to `update_workitem_status(CANCELED)`, consistent with how `workitems.py` resource already handles cancellation

## Test plan
- [x] All 288 existing tests pass
- [ ] Sourcery-ai review

Co-Authored-By: Cora <cora-2f1e43dc@sjstargetedsolutions.co.nz>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Fix DICOM UID validation and date formatting utilities and correct workitem cancellation behavior to use status updates instead of creation.

Bug Fixes:
- Prevent validate_uid from shadowing the pydicom uid module so UID validity checks work at runtime.
- Ensure to_dicom_date_str falls back to a valid DA-format strftime pattern instead of misusing the VR enum.
- Make cancel_workitem update a workitem’s status to CANCELED and return the updated entity instead of creating a new workitem and sending creation notifications.