### PR TITLE
test: coverage for dicom_utils, workitem_service, and app

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,3 +56,4 @@ venv.bak/
 
 #Apple
 .DS_Store
+requirements.txt

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -124,6 +124,7 @@ pydicom-xml = { git = "https://github.com/sjswerdloff/pydicom-xml", rev = "06032
 
 [dependency-groups]
 dev = [
+    "mypy>=1.15.0",
     "pre-commit>=4.2.0",
     "pytest>=8.3.5",
     "pytest-asyncio>=0.26.0",

--- a/tests/unit/domain/test_workitem_service.py
+++ b/tests/unit/domain/test_workitem_service.py
@@ -1,5 +1,6 @@
 """Unit tests for WorkItemService covering all branches."""
 
+import logging
 from unittest.mock import MagicMock
 
 import pytest
@@ -75,16 +76,19 @@ class TestCreateWorkitem:
     def test_create_workitem_without_notification_service_logs_warning(
         self,
         mock_repository: MagicMock,
+        caplog: pytest.LogCaptureFixture,
     ) -> None:
         """Contract: create_workitem skips notification and logs warning when service is None (line 46)."""
         workitem = _make_workitem()
         mock_repository.create.return_value = workitem
         service = _make_service(mock_repository, notification_service=None)
 
-        result = service.create_workitem(workitem)
+        with caplog.at_level(logging.WARNING):
+            result = service.create_workitem(workitem)
 
-        # No notification service means no notify call — just logs and returns
         assert result is workitem
+        warning_records = [r for r in caplog.records if r.levelno >= logging.WARNING]
+        assert warning_records, "Expected a WARNING log when notification_service is None"
 
     def test_create_workitem_returns_repository_result(
         self,
@@ -260,6 +264,7 @@ class TestUpdateWorkitemStatus:
     def test_update_without_notification_service_logs_warning(
         self,
         mock_repository: MagicMock,
+        caplog: pytest.LogCaptureFixture,
     ) -> None:
         """Contract: successful update without notification service logs warning (line 105)."""
         workitem = _make_workitem(status="SCHEDULED")
@@ -267,10 +272,13 @@ class TestUpdateWorkitemStatus:
         mock_repository.update.return_value = workitem
         service = _make_service(mock_repository, notification_service=None)
 
-        result_workitem, success = service.update_workitem_status("1.2.3.4.5", WorkItemStatus.IN_PROGRESS, "txn-001")
+        with caplog.at_level(logging.WARNING):
+            result_workitem, success = service.update_workitem_status("1.2.3.4.5", WorkItemStatus.IN_PROGRESS, "txn-001")
 
         assert success is True
         assert result_workitem is workitem
+        warning_records = [r for r in caplog.records if r.levelno >= logging.WARNING]
+        assert any("notification" in r.getMessage().lower() for r in warning_records)
 
     def test_update_in_progress_stores_transaction_uid(
         self,

--- a/tests/unit/domain/test_workitem_service.py
+++ b/tests/unit/domain/test_workitem_service.py
@@ -1,0 +1,362 @@
+"""Unit tests for WorkItemService covering all branches."""
+
+from unittest.mock import MagicMock
+
+import pytest
+from pydicom import Dataset
+
+from pyupsrs.domain.models.ups import WorkItem, WorkItemStatus
+from pyupsrs.domain.services.workitem_service import WorkItemService
+from pyupsrs.storage.repositories.workitem_repository import WorkItemRepository
+from pyupsrs.websocket.notification_service import NotificationService
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def mock_repository() -> MagicMock:
+    """Mock WorkItemRepository."""
+    return MagicMock(spec=WorkItemRepository)
+
+
+@pytest.fixture
+def mock_notification_service() -> MagicMock:
+    """Mock NotificationService."""
+    return MagicMock(spec=NotificationService)
+
+
+def _make_workitem(status: str = "SCHEDULED", transaction_uid: str | None = None) -> WorkItem:
+    """Build a WorkItem with a Dataset containing the given ProcedureStepState."""
+    ds = Dataset()
+    ds.SOPInstanceUID = "1.2.3.4.5"
+    ds.AffectedSOPInstanceUID = "1.2.3.4.5"
+    ds.ProcedureStepState = status
+    workitem = WorkItem(ds=ds)
+    workitem.transaction_uid = transaction_uid
+    return workitem
+
+
+def _make_service(
+    repository: WorkItemRepository,
+    notification_service: NotificationService | None,
+) -> WorkItemService:
+    """Construct a WorkItemService with optional notification service."""
+    return WorkItemService(
+        workitem_repository=repository,
+        notification_service=notification_service,
+    )
+
+
+# ---------------------------------------------------------------------------
+# create_workitem tests
+# ---------------------------------------------------------------------------
+
+
+class TestCreateWorkitem:
+    """Tests for create_workitem method."""
+
+    def test_create_workitem_with_notification_service_calls_notify(
+        self,
+        mock_repository: MagicMock,
+        mock_notification_service: MagicMock,
+    ) -> None:
+        """Contract: create_workitem notifies when notification service is present."""
+        workitem = _make_workitem()
+        mock_repository.create.return_value = workitem
+        service = _make_service(mock_repository, mock_notification_service)
+
+        result = service.create_workitem(workitem)
+
+        mock_notification_service.notify_creation.assert_called_once_with(workitem)
+        assert result is workitem
+
+    def test_create_workitem_without_notification_service_logs_warning(
+        self,
+        mock_repository: MagicMock,
+    ) -> None:
+        """Contract: create_workitem skips notification and logs warning when service is None (line 46)."""
+        workitem = _make_workitem()
+        mock_repository.create.return_value = workitem
+        service = _make_service(mock_repository, notification_service=None)
+
+        result = service.create_workitem(workitem)
+
+        # No notification service means no notify call — just logs and returns
+        assert result is workitem
+
+    def test_create_workitem_returns_repository_result(
+        self,
+        mock_repository: MagicMock,
+        mock_notification_service: MagicMock,
+    ) -> None:
+        """Contract: create_workitem returns whatever the repository returns."""
+        incoming = _make_workitem()
+        stored = _make_workitem()
+        mock_repository.create.return_value = stored
+        service = _make_service(mock_repository, mock_notification_service)
+
+        result = service.create_workitem(incoming)
+
+        assert result is stored
+
+
+# ---------------------------------------------------------------------------
+# update_workitem_status tests
+# ---------------------------------------------------------------------------
+
+
+class TestUpdateWorkitemStatus:
+    """Tests for update_workitem_status method."""
+
+    def test_update_scheduled_workitem_succeeds(
+        self,
+        mock_repository: MagicMock,
+        mock_notification_service: MagicMock,
+    ) -> None:
+        """Contract: updating a SCHEDULED workitem with any transaction_uid succeeds."""
+        workitem = _make_workitem(status="SCHEDULED")
+        mock_repository.get_by_uid.return_value = workitem
+        mock_repository.update.return_value = workitem
+        service = _make_service(mock_repository, mock_notification_service)
+
+        result_workitem, success = service.update_workitem_status("1.2.3.4.5", WorkItemStatus.IN_PROGRESS, "txn-001")
+
+        assert success is True
+        assert result_workitem is workitem
+
+    def test_update_returns_workitem_instance_from_non_workitem_repository_result(
+        self,
+        mock_repository: MagicMock,
+        mock_notification_service: MagicMock,
+    ) -> None:
+        """Contract: when repository returns non-WorkItem, it is wrapped in WorkItem (line 67)."""
+        ds = Dataset()
+        ds.SOPInstanceUID = "1.2.3.4.5"
+        ds.AffectedSOPInstanceUID = "1.2.3.4.5"
+        ds.ProcedureStepState = "SCHEDULED"
+        # Repository returns a bare Dataset, not a WorkItem
+        mock_repository.get_by_uid.return_value = ds
+        wrapped_workitem = _make_workitem(status="SCHEDULED")
+        mock_repository.update.return_value = wrapped_workitem
+        service = _make_service(mock_repository, mock_notification_service)
+
+        result_workitem, success = service.update_workitem_status("1.2.3.4.5", WorkItemStatus.IN_PROGRESS, "txn-001")
+
+        # The service wrapped the Dataset and continued — update succeeded
+        assert success is True
+
+    def test_update_returns_false_when_procedure_step_state_missing(
+        self,
+        mock_repository: MagicMock,
+        mock_notification_service: MagicMock,
+    ) -> None:
+        """Contract: workitem missing ProcedureStepState returns (workitem, False) (lines 77-80)."""
+        ds = Dataset()
+        ds.SOPInstanceUID = "1.2.3.4.5"
+        # No ProcedureStepState attribute
+        workitem = WorkItem(ds=ds)
+        mock_repository.get_by_uid.return_value = workitem
+        service = _make_service(mock_repository, mock_notification_service)
+
+        result_workitem, success = service.update_workitem_status("1.2.3.4.5", WorkItemStatus.IN_PROGRESS, "txn-001")
+
+        assert success is False
+        assert result_workitem is workitem
+
+    def test_update_non_scheduled_workitem_without_transaction_uid_returns_false(
+        self,
+        mock_repository: MagicMock,
+        mock_notification_service: MagicMock,
+    ) -> None:
+        """Contract: non-SCHEDULED workitem with no transaction_uid returns (workitem, False) (lines 83-86)."""
+        workitem = _make_workitem(status="IN PROGRESS", transaction_uid="txn-original")
+        mock_repository.get_by_uid.return_value = workitem
+        service = _make_service(mock_repository, mock_notification_service)
+
+        result_workitem, success = service.update_workitem_status("1.2.3.4.5", WorkItemStatus.COMPLETED, transaction_uid="")
+
+        assert success is False
+        assert result_workitem is workitem
+
+    def test_update_non_scheduled_workitem_with_wrong_transaction_uid_returns_false(
+        self,
+        mock_repository: MagicMock,
+        mock_notification_service: MagicMock,
+    ) -> None:
+        """Contract: non-SCHEDULED workitem with mismatched transaction_uid returns (workitem, False) (lines 83-86)."""
+        workitem = _make_workitem(status="IN PROGRESS", transaction_uid="txn-original")
+        mock_repository.get_by_uid.return_value = workitem
+        service = _make_service(mock_repository, mock_notification_service)
+
+        result_workitem, success = service.update_workitem_status(
+            "1.2.3.4.5", WorkItemStatus.COMPLETED, transaction_uid="txn-wrong"
+        )
+
+        assert success is False
+        assert result_workitem is workitem
+
+    def test_update_completed_workitem_returns_false(
+        self,
+        mock_repository: MagicMock,
+        mock_notification_service: MagicMock,
+    ) -> None:
+        """Contract: COMPLETED workitem cannot be updated, returns (workitem, False) (lines 89-90)."""
+        workitem = _make_workitem(status="COMPLETED", transaction_uid="txn-001")
+        mock_repository.get_by_uid.return_value = workitem
+        service = _make_service(mock_repository, mock_notification_service)
+
+        result_workitem, success = service.update_workitem_status(
+            "1.2.3.4.5", WorkItemStatus.CANCELED, transaction_uid="txn-001"
+        )
+
+        assert success is False
+        assert result_workitem is workitem
+
+    def test_update_canceled_workitem_returns_false(
+        self,
+        mock_repository: MagicMock,
+        mock_notification_service: MagicMock,
+    ) -> None:
+        """Contract: CANCELED workitem cannot be updated, returns (workitem, False) (lines 89-90)."""
+        workitem = _make_workitem(status="CANCELED", transaction_uid="txn-001")
+        mock_repository.get_by_uid.return_value = workitem
+        service = _make_service(mock_repository, mock_notification_service)
+
+        result_workitem, success = service.update_workitem_status(
+            "1.2.3.4.5", WorkItemStatus.SCHEDULED, transaction_uid="txn-001"
+        )
+
+        assert success is False
+        assert result_workitem is workitem
+
+    def test_update_raises_and_propagates_repository_exception(
+        self,
+        mock_repository: MagicMock,
+        mock_notification_service: MagicMock,
+    ) -> None:
+        """Contract: exceptions from repository propagate to caller (lines 105-108)."""
+        mock_repository.get_by_uid.side_effect = RuntimeError("DB connection lost")
+        service = _make_service(mock_repository, mock_notification_service)
+
+        with pytest.raises(RuntimeError, match="DB connection lost"):
+            service.update_workitem_status("1.2.3.4.5", WorkItemStatus.IN_PROGRESS, "txn-001")
+
+    def test_update_raises_and_propagates_update_repository_exception(
+        self,
+        mock_repository: MagicMock,
+        mock_notification_service: MagicMock,
+    ) -> None:
+        """Contract: exceptions from repository.update propagate to caller (lines 105-108)."""
+        workitem = _make_workitem(status="SCHEDULED")
+        mock_repository.get_by_uid.return_value = workitem
+        mock_repository.update.side_effect = RuntimeError("update failed")
+        service = _make_service(mock_repository, mock_notification_service)
+
+        with pytest.raises(RuntimeError, match="update failed"):
+            service.update_workitem_status("1.2.3.4.5", WorkItemStatus.IN_PROGRESS, "txn-001")
+
+    def test_update_without_notification_service_logs_warning(
+        self,
+        mock_repository: MagicMock,
+    ) -> None:
+        """Contract: successful update without notification service logs warning (line 105)."""
+        workitem = _make_workitem(status="SCHEDULED")
+        mock_repository.get_by_uid.return_value = workitem
+        mock_repository.update.return_value = workitem
+        service = _make_service(mock_repository, notification_service=None)
+
+        result_workitem, success = service.update_workitem_status("1.2.3.4.5", WorkItemStatus.IN_PROGRESS, "txn-001")
+
+        assert success is True
+        assert result_workitem is workitem
+
+    def test_update_in_progress_stores_transaction_uid(
+        self,
+        mock_repository: MagicMock,
+        mock_notification_service: MagicMock,
+    ) -> None:
+        """Contract: transitioning to IN_PROGRESS stores the transaction_uid on the workitem."""
+        workitem = _make_workitem(status="SCHEDULED")
+        mock_repository.get_by_uid.return_value = workitem
+        mock_repository.update.return_value = workitem
+        service = _make_service(mock_repository, mock_notification_service)
+
+        service.update_workitem_status("1.2.3.4.5", WorkItemStatus.IN_PROGRESS, "txn-new")
+
+        assert workitem.transaction_uid == "txn-new"
+
+    def test_update_non_scheduled_with_correct_transaction_uid_succeeds(
+        self,
+        mock_repository: MagicMock,
+        mock_notification_service: MagicMock,
+    ) -> None:
+        """Contract: non-SCHEDULED workitem with matching transaction_uid can be updated."""
+        workitem = _make_workitem(status="IN PROGRESS", transaction_uid="txn-correct")
+        mock_repository.get_by_uid.return_value = workitem
+        mock_repository.update.return_value = workitem
+        service = _make_service(mock_repository, mock_notification_service)
+
+        result_workitem, success = service.update_workitem_status(
+            "1.2.3.4.5", WorkItemStatus.COMPLETED, transaction_uid="txn-correct"
+        )
+
+        assert success is True
+        assert result_workitem is workitem
+
+
+# ---------------------------------------------------------------------------
+# cancel_workitem tests
+# ---------------------------------------------------------------------------
+
+
+class TestCancelWorkitem:
+    """Tests for cancel_workitem method."""
+
+    def test_cancel_delegates_to_update_workitem_status(
+        self,
+        mock_repository: MagicMock,
+        mock_notification_service: MagicMock,
+    ) -> None:
+        """Contract: cancel_workitem delegates to update_workitem_status with CANCELED (line 122)."""
+        workitem = _make_workitem(status="SCHEDULED")
+        workitem.transaction_uid = "txn-cancel"
+        mock_repository.get_by_uid.return_value = workitem
+        mock_repository.update.return_value = workitem
+        service = _make_service(mock_repository, mock_notification_service)
+
+        result_workitem, success = service.cancel_workitem(workitem)
+
+        assert success is True
+        assert result_workitem is workitem
+
+    def test_cancel_passes_workitem_transaction_uid(
+        self,
+        mock_repository: MagicMock,
+        mock_notification_service: MagicMock,
+    ) -> None:
+        """Contract: cancel_workitem forwards the workitem's own transaction_uid."""
+        workitem = _make_workitem(status="IN PROGRESS", transaction_uid="txn-lock")
+        mock_repository.get_by_uid.return_value = workitem
+        mock_repository.update.return_value = workitem
+        service = _make_service(mock_repository, mock_notification_service)
+
+        result_workitem, success = service.cancel_workitem(workitem)
+
+        # Matching transaction_uid means cancel of IN PROGRESS workitem succeeds
+        assert success is True
+
+    def test_cancel_returns_false_for_already_canceled_workitem(
+        self,
+        mock_repository: MagicMock,
+        mock_notification_service: MagicMock,
+    ) -> None:
+        """Contract: canceling an already CANCELED workitem returns (workitem, False)."""
+        workitem = _make_workitem(status="CANCELED", transaction_uid="txn-lock")
+        mock_repository.get_by_uid.return_value = workitem
+        service = _make_service(mock_repository, mock_notification_service)
+
+        result_workitem, success = service.cancel_workitem(workitem)
+
+        assert success is False

--- a/tests/unit/test_app.py
+++ b/tests/unit/test_app.py
@@ -10,6 +10,7 @@ Tests verify:
 - CLI accepts --database-uri and --auth / --no-auth flags
 """
 
+import os
 from collections.abc import Generator
 from unittest.mock import MagicMock, patch
 
@@ -23,17 +24,6 @@ from pyupsrs.config import Config
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
-
-_EXPECTED_ROUTES = [
-    "/workitems/1.2.840.10008.5.1.4.34.5/subscribers/{aetitle}/suspend",
-    "/workitems/1.2.840.10008.5.1.4.34.5.1/subscribers/{aetitle}/suspend",
-    "/workitems/{workitem_uid}/subscribers/{aetitle}",
-    "/workitems/{workitem_uid}/state",
-    "/workitems/{workitem_uid}/cancelrequest",
-    "/workitems/{workitem_uid}",
-    "/workitems",
-    "/ws/subscribers/{subscriber_id}",
-]
 
 
 def _make_mock_service_provider() -> MagicMock:
@@ -190,38 +180,47 @@ class TestMainCli:
         runner = CliRunner()
         sentinel_uri = "sqlite:///test_smoke.db"
 
-        with (
-            patch("pyupsrs.app.uvicorn_main"),
-            patch("pyupsrs.app.get_config", return_value=Config()),
-            patch("pyupsrs.app.configure_logging"),
-        ):
-            result = runner.invoke(main, ["--database-uri", sentinel_uri])
+        with patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("PYUPSRS_DATABASE_URI", None)
+            with (
+                patch("pyupsrs.app.uvicorn_main"),
+                patch("pyupsrs.app.get_config", return_value=Config()),
+                patch("pyupsrs.app.configure_logging"),
+            ):
+                result = runner.invoke(main, ["--database-uri", sentinel_uri])
 
-        # The CLI sets the env var before calling uvicorn; CliRunner isolates env by
-        # default only if mix_env=False (the default), so we verify via exit code and
-        # the absence of an unhandled exception.
+            assert os.environ.get("PYUPSRS_DATABASE_URI") == sentinel_uri
+
         assert result.exception is None or isinstance(result.exception, SystemExit)
 
     def test_cli_no_auth_flag(self) -> None:
-        """Contract: --no-auth flag is accepted without error."""
+        """Contract: --no-auth flag sets PYUPSRS_AUTH_ENABLED to 'false'."""
         runner = CliRunner()
-        with (
-            patch("pyupsrs.app.uvicorn_main"),
-            patch("pyupsrs.app.get_config", return_value=Config()),
-            patch("pyupsrs.app.configure_logging"),
-        ):
-            result = runner.invoke(main, ["--no-auth"])
+        with patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("PYUPSRS_AUTH_ENABLED", None)
+            with (
+                patch("pyupsrs.app.uvicorn_main"),
+                patch("pyupsrs.app.get_config", return_value=Config()),
+                patch("pyupsrs.app.configure_logging"),
+            ):
+                result = runner.invoke(main, ["--no-auth"])
+
+            assert os.environ.get("PYUPSRS_AUTH_ENABLED") == "false"
 
         assert result.exception is None or isinstance(result.exception, SystemExit)
 
     def test_cli_auth_flag(self) -> None:
-        """Contract: --auth flag is accepted without error."""
+        """Contract: --auth flag sets PYUPSRS_AUTH_ENABLED to 'true'."""
         runner = CliRunner()
-        with (
-            patch("pyupsrs.app.uvicorn_main"),
-            patch("pyupsrs.app.get_config", return_value=Config()),
-            patch("pyupsrs.app.configure_logging"),
-        ):
-            result = runner.invoke(main, ["--auth"])
+        with patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("PYUPSRS_AUTH_ENABLED", None)
+            with (
+                patch("pyupsrs.app.uvicorn_main"),
+                patch("pyupsrs.app.get_config", return_value=Config()),
+                patch("pyupsrs.app.configure_logging"),
+            ):
+                result = runner.invoke(main, ["--auth"])
+
+            assert os.environ.get("PYUPSRS_AUTH_ENABLED") == "true"
 
         assert result.exception is None or isinstance(result.exception, SystemExit)

--- a/tests/unit/test_app.py
+++ b/tests/unit/test_app.py
@@ -1,0 +1,227 @@
+"""
+Smoke tests for pyupsrs/app.py.
+
+Tests verify:
+- create_app() returns a valid application object without errors
+- Routes are registered for all expected URL patterns
+- Auth middleware is included when auth_enabled is True
+- Auth middleware is absent when auth_enabled is False
+- CLI --help option does not crash
+- CLI accepts --database-uri and --auth / --no-auth flags
+"""
+
+from collections.abc import Generator
+from unittest.mock import MagicMock, patch
+
+import pytest
+from click.testing import CliRunner
+from uvicorn.middleware.proxy_headers import ProxyHeadersMiddleware
+
+from pyupsrs.app import create_app, main
+from pyupsrs.config import Config
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_EXPECTED_ROUTES = [
+    "/workitems/1.2.840.10008.5.1.4.34.5/subscribers/{aetitle}/suspend",
+    "/workitems/1.2.840.10008.5.1.4.34.5.1/subscribers/{aetitle}/suspend",
+    "/workitems/{workitem_uid}/subscribers/{aetitle}",
+    "/workitems/{workitem_uid}/state",
+    "/workitems/{workitem_uid}/cancelrequest",
+    "/workitems/{workitem_uid}",
+    "/workitems",
+    "/ws/subscribers/{subscriber_id}",
+]
+
+
+def _make_mock_service_provider() -> MagicMock:
+    """Return a MagicMock configured with the attributes create_app() consumes."""
+    sp = MagicMock()
+    sp.subscription_service = MagicMock()
+    sp.workitem_service = MagicMock()
+    sp.connection_manager = MagicMock()
+    return sp
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def mock_service_provider() -> Generator[MagicMock, None, None]:
+    """Patch ServiceProvider.get_instance so no database is touched."""
+    sp = _make_mock_service_provider()
+    with patch("pyupsrs.app.ServiceProvider") as mock_cls:
+        mock_cls.get_instance.return_value = sp
+        yield sp
+
+
+@pytest.fixture()
+def config_no_auth() -> Config:
+    """Return a Config with authentication disabled."""
+    return Config(auth_enabled=False)
+
+
+@pytest.fixture()
+def config_with_auth() -> Config:
+    """Return a Config with authentication enabled."""
+    return Config(auth_enabled=True)
+
+
+# ---------------------------------------------------------------------------
+# create_app() smoke tests
+# ---------------------------------------------------------------------------
+
+
+class TestCreateApp:
+    """Smoke tests for create_app()."""
+
+    def test_create_app_returns_proxy_middleware(self, mock_service_provider: MagicMock) -> None:
+        """Contract: create_app() returns a ProxyHeadersMiddleware wrapping the Falcon app."""
+        with patch("pyupsrs.app.get_config", return_value=Config(auth_enabled=False)):
+            app = create_app()
+
+        assert isinstance(app, ProxyHeadersMiddleware)
+
+    def test_create_app_without_auth(self, mock_service_provider: MagicMock) -> None:
+        """Contract: create_app() succeeds when auth is disabled."""
+        with patch("pyupsrs.app.get_config", return_value=Config(auth_enabled=False)):
+            app = create_app()
+
+        assert app is not None
+
+    def test_create_app_with_auth(self, mock_service_provider: MagicMock) -> None:
+        """Contract: create_app() succeeds when auth is enabled."""
+        with patch("pyupsrs.app.get_config", return_value=Config(auth_enabled=True)):
+            app = create_app()
+
+        assert app is not None
+
+    def test_create_app_inner_falcon_app_has_expected_routes(self, mock_service_provider: MagicMock) -> None:
+        """Contract: the Falcon app inside the proxy wrapper has all expected routes registered."""
+        with patch("pyupsrs.app.get_config", return_value=Config(auth_enabled=False)):
+            outer_app = create_app()
+
+        # ProxyHeadersMiddleware stores the wrapped app as .app
+        falcon_app = outer_app.app  # type: ignore[attr-defined]
+
+        # Substitute concrete values for URL template params so the compiled router
+        # can match them; the template segments we care about are {workitem_uid},
+        # {aetitle}, and {subscriber_id}.
+        concrete_routes = [
+            "/workitems/1.2.840.10008.5.1.4.34.5/subscribers/MYAE/suspend",
+            "/workitems/1.2.840.10008.5.1.4.34.5.1/subscribers/MYAE/suspend",
+            "/workitems/1.2.3.4.5/subscribers/MYAE",
+            "/workitems/1.2.3.4.5/state",
+            "/workitems/1.2.3.4.5/cancelrequest",
+            "/workitems/1.2.3.4.5",
+            "/workitems",
+            "/ws/subscribers/sub-001",
+        ]
+        router = falcon_app._router
+        for route in concrete_routes:
+            result = router.find(route)
+            assert result is not None, f"Route not registered (tested via concrete URI): {route}"
+
+    def test_create_app_registers_dicom_json_media_handler(self, mock_service_provider: MagicMock) -> None:
+        """Contract: DICOM+JSON media handler is registered on both request and response options."""
+        with patch("pyupsrs.app.get_config", return_value=Config(auth_enabled=False)):
+            outer_app = create_app()
+
+        falcon_app = outer_app.app  # type: ignore[attr-defined]
+        assert "application/dicom+json" in falcon_app.req_options.media_handlers
+        assert "application/dicom+json" in falcon_app.resp_options.media_handlers
+
+    def test_create_app_registers_dicom_xml_media_handler(self, mock_service_provider: MagicMock) -> None:
+        """Contract: DICOM+XML media handler is registered on both request and response options."""
+        with patch("pyupsrs.app.get_config", return_value=Config(auth_enabled=False)):
+            outer_app = create_app()
+
+        falcon_app = outer_app.app  # type: ignore[attr-defined]
+        assert "application/dicom+xml" in falcon_app.req_options.media_handlers
+        assert "application/dicom+xml" in falcon_app.resp_options.media_handlers
+
+    def test_create_app_auth_middleware_included_when_enabled(self, mock_service_provider: MagicMock) -> None:
+        """Contract: AuthMiddleware appears in middleware when auth_enabled is True."""
+        from pyupsrs.api.middleware.auth import AuthMiddleware
+
+        with patch("pyupsrs.app.get_config", return_value=Config(auth_enabled=True)):
+            outer_app = create_app()
+
+        falcon_app = outer_app.app  # type: ignore[attr-defined]
+        # Falcon stores the original middleware objects in _unprepared_middleware before
+        # it compiles them into handler method tuples.
+        assert any(isinstance(m, AuthMiddleware) for m in falcon_app._unprepared_middleware)
+
+    def test_create_app_auth_middleware_absent_when_disabled(self, mock_service_provider: MagicMock) -> None:
+        """Contract: AuthMiddleware is not included when auth_enabled is False."""
+        from pyupsrs.api.middleware.auth import AuthMiddleware
+
+        with patch("pyupsrs.app.get_config", return_value=Config(auth_enabled=False)):
+            outer_app = create_app()
+
+        falcon_app = outer_app.app  # type: ignore[attr-defined]
+        assert not any(isinstance(m, AuthMiddleware) for m in falcon_app._unprepared_middleware)
+
+
+# ---------------------------------------------------------------------------
+# CLI smoke tests
+# ---------------------------------------------------------------------------
+
+
+class TestMainCli:
+    """Smoke tests for the Click CLI entry point."""
+
+    def test_cli_help_exits_zero(self) -> None:
+        """Contract: --help flag exits with code 0 without crashing."""
+        runner = CliRunner()
+        with patch("pyupsrs.app.uvicorn_main") as mock_uvicorn:
+            mock_uvicorn.side_effect = SystemExit(0)
+            result = runner.invoke(main, ["--help"])
+
+        # Click exits 0 for --help; our code also sys.exit(0) after our help block.
+        assert result.exit_code == 0
+
+    def test_cli_database_uri_option_sets_env_var(self) -> None:
+        """Contract: --database-uri stores the value in PYUPSRS_DATABASE_URI."""
+        runner = CliRunner()
+        sentinel_uri = "sqlite:///test_smoke.db"
+
+        with (
+            patch("pyupsrs.app.uvicorn_main"),
+            patch("pyupsrs.app.get_config", return_value=Config()),
+            patch("pyupsrs.app.configure_logging"),
+        ):
+            result = runner.invoke(main, ["--database-uri", sentinel_uri])
+
+        # The CLI sets the env var before calling uvicorn; CliRunner isolates env by
+        # default only if mix_env=False (the default), so we verify via exit code and
+        # the absence of an unhandled exception.
+        assert result.exception is None or isinstance(result.exception, SystemExit)
+
+    def test_cli_no_auth_flag(self) -> None:
+        """Contract: --no-auth flag is accepted without error."""
+        runner = CliRunner()
+        with (
+            patch("pyupsrs.app.uvicorn_main"),
+            patch("pyupsrs.app.get_config", return_value=Config()),
+            patch("pyupsrs.app.configure_logging"),
+        ):
+            result = runner.invoke(main, ["--no-auth"])
+
+        assert result.exception is None or isinstance(result.exception, SystemExit)
+
+    def test_cli_auth_flag(self) -> None:
+        """Contract: --auth flag is accepted without error."""
+        runner = CliRunner()
+        with (
+            patch("pyupsrs.app.uvicorn_main"),
+            patch("pyupsrs.app.get_config", return_value=Config()),
+            patch("pyupsrs.app.configure_logging"),
+        ):
+            result = runner.invoke(main, ["--auth"])
+
+        assert result.exception is None or isinstance(result.exception, SystemExit)

--- a/tests/unit/test_dicom_utils.py
+++ b/tests/unit/test_dicom_utils.py
@@ -1,0 +1,206 @@
+"""
+Unit tests for pyupsrs.utils.dicom_utils.
+
+Tests cover:
+- VR_STRFTIME contains expected keys (DA, TM, DT)
+- generate_uid returns a non-empty string that is a valid DICOM UID
+- validate_uid returns True for valid UIDs and False for invalid ones
+- to_dicom_date_str formats correctly for DA, TM, and DT VRs
+- to_dicom_date_str falls back to DA format (%Y%m%d) for unknown VR
+"""
+
+from datetime import datetime
+
+import pytest
+from pydicom import valuerep
+
+from pyupsrs.utils.dicom_utils import VR_STRFTIME, generate_uid, to_dicom_date_str, validate_uid
+
+# ---------------------------------------------------------------------------
+# VR_STRFTIME constant
+# ---------------------------------------------------------------------------
+
+
+def test_vr_strftime_contains_da_key() -> None:
+    """Contract: VR_STRFTIME has an entry for the DA (date) VR."""
+    assert valuerep.VR.DA in VR_STRFTIME
+
+
+def test_vr_strftime_contains_tm_key() -> None:
+    """Contract: VR_STRFTIME has an entry for the TM (time) VR."""
+    assert valuerep.VR.TM in VR_STRFTIME
+
+
+def test_vr_strftime_contains_dt_key() -> None:
+    """Contract: VR_STRFTIME has an entry for the DT (datetime) VR."""
+    assert valuerep.VR.DT in VR_STRFTIME
+
+
+def test_vr_strftime_da_format_produces_8_digits() -> None:
+    """Contract: DA format string produces an 8-digit date (YYYYMMDD)."""
+    dt = datetime(2025, 3, 7, 12, 30, 45)
+    formatted = dt.strftime(VR_STRFTIME[valuerep.VR.DA])
+    assert formatted == "20250307"
+
+
+def test_vr_strftime_tm_format_produces_hhmmss_microseconds() -> None:
+    """Contract: TM format string produces HHMMSS.ffffff."""
+    dt = datetime(2025, 3, 7, 12, 30, 45, 123456)
+    formatted = dt.strftime(VR_STRFTIME[valuerep.VR.TM])
+    assert formatted == "123045.123456"
+
+
+def test_vr_strftime_dt_format_produces_combined_string() -> None:
+    """Contract: DT format string produces YYYYMMDDHHmmSS.ffffff."""
+    dt = datetime(2025, 3, 7, 12, 30, 45, 123456)
+    formatted = dt.strftime(VR_STRFTIME[valuerep.VR.DT])
+    assert formatted == "20250307123045.123456"
+
+
+# ---------------------------------------------------------------------------
+# generate_uid
+# ---------------------------------------------------------------------------
+
+
+def test_generate_uid_returns_string() -> None:
+    """Contract: generate_uid returns a str instance."""
+    result = generate_uid()
+    assert isinstance(result, str)
+
+
+def test_generate_uid_returns_non_empty_string() -> None:
+    """Contract: generate_uid returns a non-empty string."""
+    result = generate_uid()
+    assert len(result) > 0
+
+
+def test_generate_uid_returns_valid_dicom_uid() -> None:
+    """Contract: the UID returned by generate_uid passes validate_uid."""
+    result = generate_uid()
+    assert validate_uid(result) is True
+
+
+def test_generate_uid_produces_unique_values() -> None:
+    """Contract: successive calls to generate_uid return different values."""
+    uid1 = generate_uid()
+    uid2 = generate_uid()
+    assert uid1 != uid2
+
+
+# ---------------------------------------------------------------------------
+# validate_uid
+# ---------------------------------------------------------------------------
+
+
+def test_validate_uid_returns_true_for_generated_uid() -> None:
+    """Contract: validate_uid returns True for a freshly generated UID."""
+    valid_uid = generate_uid()
+    assert validate_uid(valid_uid) is True
+
+
+def test_validate_uid_returns_true_for_well_known_uid() -> None:
+    """Contract: validate_uid returns True for a well-known DICOM UID."""
+    # 1.2.840.10008.1.2 = Implicit VR Little Endian Transfer Syntax
+    assert validate_uid("1.2.840.10008.1.2") is True
+
+
+def test_validate_uid_returns_false_for_empty_string() -> None:
+    """Contract: validate_uid returns False for an empty string."""
+    assert validate_uid("") is False
+
+
+def test_validate_uid_returns_false_for_uid_with_leading_zero_component() -> None:
+    """Contract: validate_uid returns False when a component has a leading zero."""
+    # Each component must not have a leading zero (except the component '0' itself)
+    assert validate_uid("1.02.3") is False
+
+
+def test_validate_uid_returns_false_for_uid_with_non_numeric_characters() -> None:
+    """Contract: validate_uid returns False for UIDs containing letters."""
+    assert validate_uid("1.2.abc.4") is False
+
+
+def test_validate_uid_returns_false_for_uid_exceeding_64_chars() -> None:
+    """Contract: validate_uid returns False for UIDs longer than 64 characters."""
+    # Build a UID that is guaranteed to exceed 64 characters
+    long_uid = "1." + ".".join(["1234567890"] * 7)  # > 64 chars
+    assert len(long_uid) > 64
+    assert validate_uid(long_uid) is False
+
+
+# ---------------------------------------------------------------------------
+# to_dicom_date_str
+# ---------------------------------------------------------------------------
+
+_REFERENCE_DT = datetime(2024, 11, 5, 8, 3, 7, 654321)
+
+
+def test_to_dicom_date_str_da_format() -> None:
+    """Contract: to_dicom_date_str with VR.DA returns YYYYMMDD."""
+    result = to_dicom_date_str(_REFERENCE_DT, valuerep.VR.DA)
+    assert result == "20241105"
+
+
+def test_to_dicom_date_str_tm_format() -> None:
+    """Contract: to_dicom_date_str with VR.TM returns HHMMSS.ffffff."""
+    result = to_dicom_date_str(_REFERENCE_DT, valuerep.VR.TM)
+    assert result == "080307.654321"
+
+
+def test_to_dicom_date_str_dt_format() -> None:
+    """Contract: to_dicom_date_str with VR.DT returns YYYYMMDDHHmmSS.ffffff."""
+    result = to_dicom_date_str(_REFERENCE_DT, valuerep.VR.DT)
+    assert result == "20241105080307.654321"
+
+
+def test_to_dicom_date_str_default_vr_is_da() -> None:
+    """Contract: to_dicom_date_str with no VR argument defaults to DA format."""
+    result_default = to_dicom_date_str(_REFERENCE_DT)
+    result_explicit_da = to_dicom_date_str(_REFERENCE_DT, valuerep.VR.DA)
+    assert result_default == result_explicit_da
+
+
+def test_to_dicom_date_str_fallback_for_unknown_vr() -> None:
+    """Contract: to_dicom_date_str falls back to DA format for an unknown VR."""
+    # Use a VR that is not in VR_STRFTIME (e.g., LO — long string)
+    unknown_vr = valuerep.VR.LO
+    assert unknown_vr not in VR_STRFTIME
+
+    result = to_dicom_date_str(_REFERENCE_DT, unknown_vr)
+    # Fallback is the DA format string "%Y%m%d"
+    assert result == "20241105"
+
+
+def test_to_dicom_date_str_returns_string() -> None:
+    """Contract: to_dicom_date_str always returns a str."""
+    for vr in (valuerep.VR.DA, valuerep.VR.TM, valuerep.VR.DT):
+        result = to_dicom_date_str(_REFERENCE_DT, vr)
+        assert isinstance(result, str)
+
+
+def test_to_dicom_date_str_da_length_is_eight() -> None:
+    """Contract: DA output is exactly 8 characters."""
+    result = to_dicom_date_str(_REFERENCE_DT, valuerep.VR.DA)
+    assert len(result) == 8
+
+
+def test_to_dicom_date_str_dt_length_is_21() -> None:
+    """Contract: DT output is exactly 21 characters (YYYYMMDDHHmmSS.ffffff)."""
+    result = to_dicom_date_str(_REFERENCE_DT, valuerep.VR.DT)
+    assert len(result) == 21
+
+
+@pytest.mark.parametrize(
+    ("dt", "vr", "expected"),
+    [
+        (datetime(2000, 1, 1, 0, 0, 0, 0), valuerep.VR.DA, "20000101"),
+        (datetime(1999, 12, 31, 23, 59, 59, 999999), valuerep.VR.DA, "19991231"),
+        (datetime(2000, 1, 1, 0, 0, 0, 0), valuerep.VR.TM, "000000.000000"),
+        (datetime(1999, 12, 31, 23, 59, 59, 999999), valuerep.VR.TM, "235959.999999"),
+        (datetime(2000, 1, 1, 0, 0, 0, 0), valuerep.VR.DT, "20000101000000.000000"),
+        (datetime(1999, 12, 31, 23, 59, 59, 999999), valuerep.VR.DT, "19991231235959.999999"),
+    ],
+)
+def test_to_dicom_date_str_parametrized_boundary_values(dt: datetime, vr: valuerep.VR, expected: str) -> None:
+    """Contract: to_dicom_date_str produces correct output at date/time boundaries."""
+    assert to_dicom_date_str(dt, vr) == expected

--- a/uv.lock
+++ b/uv.lock
@@ -680,6 +680,7 @@ docs = [
 
 [package.dev-dependencies]
 dev = [
+    { name = "mypy" },
     { name = "pre-commit" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
@@ -712,6 +713,7 @@ provides-extras = ["dev", "docs"]
 
 [package.metadata.requires-dev]
 dev = [
+    { name = "mypy", specifier = ">=1.15.0" },
     { name = "pre-commit", specifier = ">=4.2.0" },
     { name = "pytest", specifier = ">=8.3.5" },
     { name = "pytest-asyncio", specifier = ">=0.26.0" },


### PR DESCRIPTION
## Summary
- **dicom_utils.py**: 30 tests, 0% → 100% — generate_uid, validate_uid, to_dicom_date_str with all VRs and fallback
- **workitem_service.py**: 18 tests, 65% → 95% — notification_service None path, cancel delegation, state guards, exception propagation
- **app.py**: 12 tests, 0% → 98% — create_app assembly, route registration, auth middleware toggle, CLI options
- **Overall**: 79% → 85%

## Test plan
- [x] All 348 tests pass (288 existing + 60 new)
- [ ] Sourcery-ai review

Co-Authored-By: Cora <cora-2f1e43dc@sjstargetedsolutions.co.nz>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Add comprehensive unit tests for DICOM utilities, work item service behavior, and application/CLI wiring while slightly extending dev tooling.

Build:
- Add mypy as a development dependency for static type checking.

Tests:
- Add full unit test coverage for dicom_utils, including UID generation/validation and DICOM date/time formatting.
- Add unit tests for WorkItemService covering notifications, state transitions, cancellation, and error propagation.
- Add smoke tests for app creation, routing, auth middleware configuration, and CLI flags/environment interaction.