### PR TITLE
fix: PS3.18 conformance on UPS-RS create / update / cancelrequest

### DIFF
--- a/pyupsrs/api/resources/workitems.py
+++ b/pyupsrs/api/resources/workitems.py
@@ -256,6 +256,24 @@ class WorkItemsResource(LoggerMixin):
                         title="Invalid DICOM JSON", description="Request body must be valid DICOM JSON"
                     ) from e
 
+            # Per PS3.18 §11.5.1, the SOP Instance UID of the new workitem may be
+            # supplied either as the "?workitem={UID}" URL query parameter or as
+            # SOPInstanceUID in the request body. Fall back to the URL parameter
+            # when the body omits it.
+            if workitem.uid is None:
+                url_uid = req.get_param("workitem")
+                if url_uid:
+                    workitem.uid = url_uid
+                else:
+                    raise falcon.HTTPBadRequest(
+                        title="Missing SOP Instance UID",
+                        description=(
+                            "Workitem SOP Instance UID must be supplied either as the "
+                            "'workitem' URL query parameter or as SOPInstanceUID (0008,0018) "
+                            "in the request body (PS3.18 §11.5.1)."
+                        ),
+                    )
+
             resp.content_type = negotiate_content_type(req)
 
             if self.workitem_service.workitem_repository.get_by_uid(workitem.uid):
@@ -335,9 +353,9 @@ class WorkItemResource(LoggerMixin):
         else:
             resp.status = falcon.HTTP_404
 
-    async def on_put(self, req: falcon.Request, resp: falcon.Response, workitem_uid: str) -> None:
+    async def on_post(self, req: falcon.Request, resp: falcon.Response, workitem_uid: str) -> None:
         """
-        Handle PUT requests to update a workitem.
+        Handle POST requests to update a workitem (PS3.18 §11.6 Update Workitem Transaction).
 
         Args:
             req: The HTTP request.
@@ -345,7 +363,9 @@ class WorkItemResource(LoggerMixin):
             workitem_uid: The UID of the workitem.
 
         """
-        transaction_uid = req.params.get("transaction-uid")
+        # PS3.18 URI template uses "Transaction-uid" (capital T); accept the
+        # lowercase form too for legacy callers.
+        transaction_uid = req.params.get("Transaction-uid") or req.params.get("transaction-uid")
         resp.content_type = "application/json"
         resp.status = falcon.HTTP_500  # if we don't manage to reset it, it's a coding problem
         # Manually read and parse the request body
@@ -412,9 +432,29 @@ class WorkItemResource(LoggerMixin):
             self.logger.error("Internal UPS logic error, corner case not addressed?")
             self.logger.error(f"UID {workitem} and Transaction UID {transaction_uid} had Message body : {body}")
 
+
+class WorkItemCancelRequestResource(LoggerMixin):
+    """Resource for the cancel-request sub-resource (PS3.18 §11.8 Request UPS Cancellation)."""
+
+    def __init__(self, workitem_service: svc_workitem_service = None) -> None:
+        """
+        Initialize the resource.
+
+        Args:
+            workitem_service: Service for handling workitem operations.
+
+        """
+        self.workitem_service = workitem_service
+        if not self.workitem_service:
+            provider = ServiceProvider.get_instance()
+            self.workitem_service = provider.workitem_service
+
     async def on_post(self, req: falcon.Request, resp: falcon.Response, workitem_uid: str) -> None:
         """
-        Handle POST requests to cancel a workitem.
+        Handle POST requests to request cancellation of a workitem.
+
+        Per PS3.18 §11.8, the SCP is not obliged to honour the request; this
+        endpoint simply records the request.
 
         Args:
             req: The HTTP request.
@@ -423,22 +463,27 @@ class WorkItemResource(LoggerMixin):
 
         """
         try:
-            # Manually read and parse the request body
             body = await req.stream.read()
             if not body:
-                raise falcon.HTTPBadRequest(title="Empty request body", description="A valid DICOM JSON dataset is required")
+                raise falcon.HTTPBadRequest(title="Empty request body", description="A valid DICOM dataset is required")
 
-            # Parse the JSON body
+            # Dispatch on Content-Type: handles both application/dicom+json and application/dicom+xml
             try:
-                data = json.loads(body)
-            except json.JSONDecodeError as e:
-                raise falcon.HTTPBadRequest(title="Invalid JSON", description="Request body must be valid JSON") from e
+                parsed = deserialize_request_body(body, req.content_type)
+            except (json.JSONDecodeError, ET.ParseError, ValueError) as e:
+                self.logger.error("Failed to parse cancellation request body: %s", e)
+                raise falcon.HTTPBadRequest(
+                    title="Invalid request body",
+                    description="Request body must be valid DICOM JSON or XML",
+                ) from e
 
-            json_dicom = data
-            cancel_workitem = deserialize_workitem(json_dicom)
+            if isinstance(parsed, Dataset):
+                cancel_workitem = WorkItem(ds=parsed)
+            else:
+                cancel_workitem = deserialize_workitem(parsed)
             cancel_workitem.uid = workitem_uid
             cancel_workitem.ds.SOPInstanceUID = cancel_workitem.uid
-            resp.content_type = "application/dicom+json"
+            resp.content_type = negotiate_content_type(req)
 
             canceled: bool = False
 
@@ -446,25 +491,16 @@ class WorkItemResource(LoggerMixin):
             if stored_workitem is None:
                 resp.status = falcon.HTTP_404
             else:
-                # Try to cancel it
                 _, canceled = self.workitem_service.update_workitem_status(
                     workitem_uid, new_status=WorkItemStatus.CANCELED, transaction_uid=None
                 )
                 if canceled:
-                    # update to include whatever reasons and notification information
-                    # TODO: check within update to see if the update contains cancellation request information and
-                    # trigger a notification (although that notification will be a stub... this is an example, not
-                    # intended to be commercial grade)
                     self.workitem_service.workitem_repository.update(cancel_workitem)
 
                 resp.status = falcon.HTTP_202 if canceled else falcon.HTTP_409
-                # resp_media = json.dumps(workitem_response)
-                # resp.text = resp_media
 
         except Exception as e:
-            # Get a detailed traceback for debugging on the server side
             print(traceback.format_exc())
-            # Log the exception
             raise falcon.HTTPInternalServerError(title="Error processing request", description=str(e)) from e
 
 

--- a/pyupsrs/api/resources/workitems.py
+++ b/pyupsrs/api/resources/workitems.py
@@ -1,7 +1,6 @@
 """Falcon resources for UPS workitems."""
 
 import json
-import traceback
 from datetime import datetime
 from typing import Any
 from xml.etree import ElementTree as ET
@@ -258,10 +257,10 @@ class WorkItemsResource(LoggerMixin):
 
             # Per PS3.18 §11.5.1, the SOP Instance UID of the new workitem may be
             # supplied either as the "?workitem={UID}" URL query parameter or as
-            # SOPInstanceUID in the request body. Fall back to the URL parameter
-            # when the body omits it.
+            # SOPInstanceUID in the request body. If both are present they must
+            # agree; otherwise the request is ambiguous.
+            url_uid = req.get_param("workitem")
             if workitem.uid is None:
-                url_uid = req.get_param("workitem")
                 if url_uid:
                     workitem.uid = url_uid
                 else:
@@ -273,6 +272,14 @@ class WorkItemsResource(LoggerMixin):
                             "in the request body (PS3.18 §11.5.1)."
                         ),
                     )
+            elif url_uid and url_uid != workitem.uid:
+                raise falcon.HTTPBadRequest(
+                    title="Inconsistent SOP Instance UID",
+                    description=(
+                        f"'workitem' URL query parameter ({url_uid}) differs from "
+                        f"SOPInstanceUID in the request body ({workitem.uid})."
+                    ),
+                )
 
             resp.content_type = negotiate_content_type(req)
 
@@ -296,10 +303,11 @@ class WorkItemsResource(LoggerMixin):
         except falcon.HTTPError:
             raise
         except Exception as e:
-            # Get a detailed traceback for debugging on the server side
-            print(traceback.format_exc())
-            # Log the exception
-            raise falcon.HTTPInternalServerError(title="Error processing request", description=str(e)) from e
+            # Log full traceback server-side; return a generic message to the client.
+            self.logger.exception("Unhandled error processing create workitem request")
+            raise falcon.HTTPInternalServerError(
+                title="Internal server error", description="An unexpected error occurred."
+            ) from e
 
 
 class WorkItemResource(LoggerMixin):
@@ -338,10 +346,8 @@ class WorkItemResource(LoggerMixin):
             resp.status = falcon.HTTP_200
             try:
                 data, resp.content_type = serialize_dataset(workitem.ds, resp.content_type)
-            except Exception as e:
-                # Get a detailed traceback for debugging on the server side
-                print(traceback.format_exc())
-                print(f"Failed to serialise result: {e}")
+            except Exception:
+                self.logger.exception("Failed to serialise retrieved workitem")
                 resp.status = falcon.HTTP_500
                 return
 
@@ -500,8 +506,10 @@ class WorkItemCancelRequestResource(LoggerMixin):
                 resp.status = falcon.HTTP_202 if canceled else falcon.HTTP_409
 
         except Exception as e:
-            print(traceback.format_exc())
-            raise falcon.HTTPInternalServerError(title="Error processing request", description=str(e)) from e
+            self.logger.exception("Unhandled error processing cancellation request")
+            raise falcon.HTTPInternalServerError(
+                title="Internal server error", description="An unexpected error occurred."
+            ) from e
 
 
 class WorkItemStateResource(LoggerMixin):

--- a/pyupsrs/app.py
+++ b/pyupsrs/app.py
@@ -17,7 +17,13 @@ from pyupsrs.api.middleware.auth import AuthMiddleware
 from pyupsrs.api.middleware.logging import LoggingMiddleware
 from pyupsrs.api.resources.subscriptions import SubscriptionResource, SubscriptionSuspendResource
 from pyupsrs.api.resources.websocket_resource import WebSocketResource
-from pyupsrs.api.resources.workitems import DICOMJSONHandler, WorkItemResource, WorkItemsResource, WorkItemStateResource
+from pyupsrs.api.resources.workitems import (
+    DICOMJSONHandler,
+    WorkItemCancelRequestResource,
+    WorkItemResource,
+    WorkItemsResource,
+    WorkItemStateResource,
+)
 from pyupsrs.api.serializers.dicom_xml import DICOMXMLHandler
 from pyupsrs.config import get_config
 from pyupsrs.domain.services.service_provider import ServiceProvider
@@ -64,6 +70,7 @@ def create_app() -> App:
     subscription_resource = SubscriptionResource(subscription_service=service_provider.subscription_service)
     subscription_suspend_resource = SubscriptionSuspendResource(subscription_service=service_provider.subscription_service)
     workitem_resource = WorkItemResource(workitem_service=service_provider.workitem_service)
+    workitem_cancel_resource = WorkItemCancelRequestResource(workitem_service=service_provider.workitem_service)
     workitem_state_resource = WorkItemStateResource(workitem_service=service_provider.workitem_service)
     workitems_resource = WorkItemsResource(workitem_service=service_provider.workitem_service)
     websocket_resource = WebSocketResource(connection_manager=service_provider.connection_manager)
@@ -76,7 +83,7 @@ def create_app() -> App:
     app.add_route("/workitems/1.2.840.10008.5.1.4.34.5.1/subscribers/{aetitle}/suspend", subscription_suspend_resource)
     app.add_route("/workitems/{workitem_uid}/subscribers/{aetitle}", subscription_resource)
     app.add_route("/workitems/{workitem_uid}/state", workitem_state_resource)
-    app.add_route("/workitems/{workitem_uid}/cancelrequest", workitem_resource)
+    app.add_route("/workitems/{workitem_uid}/cancelrequest", workitem_cancel_resource)
     app.add_route("/workitems/{workitem_uid}", workitem_resource)
     app.add_route("/workitems", workitems_resource)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -45,7 +45,13 @@ def falcon_app() -> App:
     from pyupsrs.api.middleware.logging import LoggingMiddleware
     from pyupsrs.api.resources.subscriptions import SubscriptionResource, SubscriptionSuspendResource
     from pyupsrs.api.resources.websocket_resource import WebSocketResource
-    from pyupsrs.api.resources.workitems import DICOMJSONHandler, WorkItemResource, WorkItemsResource, WorkItemStateResource
+    from pyupsrs.api.resources.workitems import (
+        DICOMJSONHandler,
+        WorkItemCancelRequestResource,
+        WorkItemResource,
+        WorkItemsResource,
+        WorkItemStateResource,
+    )
     from pyupsrs.api.serializers.dicom_xml import DICOMXMLHandler
     from pyupsrs.config import get_config
     from pyupsrs.domain.services.service_provider import ServiceProvider
@@ -92,6 +98,7 @@ def falcon_app() -> App:
     subscription_resource = SubscriptionResource(subscription_service=service_provider.subscription_service)
     subscription_suspend_resource = SubscriptionSuspendResource(subscription_service=service_provider.subscription_service)
     workitem_resource = WorkItemResource(workitem_service=service_provider.workitem_service)
+    workitem_cancel_resource = WorkItemCancelRequestResource(workitem_service=service_provider.workitem_service)
     workitem_state_resource = WorkItemStateResource(workitem_service=service_provider.workitem_service)
     workitems_resource = WorkItemsResource(workitem_service=service_provider.workitem_service)
     websocket_resource = WebSocketResource(connection_manager=service_provider.connection_manager)
@@ -104,7 +111,7 @@ def falcon_app() -> App:
     app.add_route("/workitems/1.2.840.10008.5.1.4.34.5.1/subscribers/{aetitle}/suspend", subscription_suspend_resource)
     app.add_route("/workitems/{workitem_uid}/subscribers/{aetitle}", subscription_resource)
     app.add_route("/workitems/{workitem_uid}/state", workitem_state_resource)
-    app.add_route("/workitems/{workitem_uid}/cancelrequest", workitem_resource)
+    app.add_route("/workitems/{workitem_uid}/cancelrequest", workitem_cancel_resource)
     app.add_route("/workitems/{workitem_uid}", workitem_resource)
     app.add_route("/workitems", workitems_resource)
 

--- a/tests/integration/transactions/test_dicom_xml_workitems.py
+++ b/tests/integration/transactions/test_dicom_xml_workitems.py
@@ -479,31 +479,31 @@ class TestXmlPostWithXmlAccept:
 
 
 @pytest.mark.integration
-class TestXmlPutUpdateWorkitem:
+class TestXmlPostUpdateWorkitem:
     """PUT /workitems/{uid} with Content-Type: application/dicom+xml updates the workitem."""
 
-    def test_put_xml_update_returns_200(self, client: TestClient, created_workitem_uid: str) -> None:
+    def test_post_xml_update_returns_200(self, client: TestClient, created_workitem_uid: str) -> None:
         """Contract: PUT with a valid XML body and correct Content-Type returns HTTP 200."""
         update_ds = Dataset()
         update_ds.ScheduledProcedureStepStartDateTime = "20250601120000"
         update_ds.ScheduledProcedureStepExpirationDateTime = "20250601130000"
         xml_body = dataset_to_xml(update_ds)
 
-        result = client.simulate_put(
+        result = client.simulate_post(
             f"/workitems/{created_workitem_uid}",
             body=xml_body,
             headers={"Content-Type": "application/dicom+xml"},
         )
         assert result.status_code == 200
 
-    def test_put_xml_update_is_reflected_in_get(self, client: TestClient, created_workitem_uid: str) -> None:
+    def test_post_xml_update_is_reflected_in_get(self, client: TestClient, created_workitem_uid: str) -> None:
         """Contract: after XML PUT, the updated scheduled time is retrievable via GET."""
         scheduled_start = "20250701090000"
         update_ds = Dataset()
         update_ds.ScheduledProcedureStepStartDateTime = scheduled_start
         xml_body = dataset_to_xml(update_ds)
 
-        put_result = client.simulate_put(
+        put_result = client.simulate_post(
             f"/workitems/{created_workitem_uid}",
             body=xml_body,
             headers={"Content-Type": "application/dicom+xml"},
@@ -519,38 +519,38 @@ class TestXmlPutUpdateWorkitem:
         # ScheduledProcedureStepStartDateTime tag 00404005
         assert payload["00404005"]["Value"] == [scheduled_start]
 
-    def test_put_xml_update_empty_body_returns_400(self, client: TestClient, created_workitem_uid: str) -> None:
+    def test_post_xml_update_empty_body_returns_400(self, client: TestClient, created_workitem_uid: str) -> None:
         """Contract: PUT with empty body and XML Content-Type returns HTTP 400."""
-        result = client.simulate_put(
+        result = client.simulate_post(
             f"/workitems/{created_workitem_uid}",
             body=b"",
             headers={"Content-Type": "application/dicom+xml"},
         )
         assert result.status_code == 400
 
-    def test_put_xml_update_malformed_xml_returns_400(self, client: TestClient, created_workitem_uid: str) -> None:
+    def test_post_xml_update_malformed_xml_returns_400(self, client: TestClient, created_workitem_uid: str) -> None:
         """Contract: PUT with malformed XML body and XML Content-Type returns HTTP 400."""
-        result = client.simulate_put(
+        result = client.simulate_post(
             f"/workitems/{created_workitem_uid}",
             body=b"<NotValidXML>",
             headers={"Content-Type": "application/dicom+xml"},
         )
         assert result.status_code == 400
 
-    def test_put_xml_update_nonexistent_workitem_returns_404(self, client: TestClient) -> None:
+    def test_post_xml_update_nonexistent_workitem_returns_404(self, client: TestClient) -> None:
         """Contract: PUT XML update for a non-existent workitem UID returns HTTP 404."""
         update_ds = Dataset()
         update_ds.ScheduledProcedureStepStartDateTime = "20250601120000"
         xml_body = dataset_to_xml(update_ds)
 
-        result = client.simulate_put(
+        result = client.simulate_post(
             f"/workitems/{generate_uid()}",
             body=xml_body,
             headers={"Content-Type": "application/dicom+xml"},
         )
         assert result.status_code == 404
 
-    def test_put_xml_update_strips_procedure_step_state_with_warning(
+    def test_post_xml_update_strips_procedure_step_state_with_warning(
         self, client: TestClient, created_workitem_uid: str
     ) -> None:
         """Contract: PUT with ProcedureStepState in XML body returns 200 with a 299 warning header."""
@@ -559,7 +559,7 @@ class TestXmlPutUpdateWorkitem:
         update_ds.ScheduledProcedureStepStartDateTime = "20250601120000"
         xml_body = dataset_to_xml(update_ds)
 
-        result = client.simulate_put(
+        result = client.simulate_post(
             f"/workitems/{created_workitem_uid}",
             body=xml_body,
             headers={"Content-Type": "application/dicom+xml"},

--- a/tests/integration/transactions/test_update_workitem.py
+++ b/tests/integration/transactions/test_update_workitem.py
@@ -18,7 +18,7 @@ class TestUpdateWorkItem:
         }
         payload_bytes = json.dumps(payload).encode("utf-8")
 
-        result = client.simulate_put(
+        result = client.simulate_post(
             f"/workitems/{created_workitem_uid}",
             body=payload_bytes,
             headers={"Content-Type": "application/dicom+json"},

--- a/tests/integration/transactions/test_workitem_transactions.py
+++ b/tests/integration/transactions/test_workitem_transactions.py
@@ -81,7 +81,7 @@ def change_state_helper(client: TestClient, created_workitem_uid: str, transacti
 
     location = f"/workitems/{created_workitem_uid}/state"
     payload_bytes = json.dumps(payload).encode("utf-8")
-    # Send request
+    # Send request (PUT per PS3.18 §11.7.1)
     return client.simulate_put(location, body=payload_bytes, headers={"Content-Type": "application/dicom+json"})
 
 
@@ -94,7 +94,7 @@ def update_workitem_helper(client: TestClient, created_workitem_uid: str, sample
 
     payload_bytes = json.dumps(payload).encode("utf-8")
     # Send request
-    return client.simulate_put(
+    return client.simulate_post(
         f"/workitems/{created_workitem_uid}", body=payload_bytes, headers={"Content-Type": "application/dicom+json"}
     )
 


### PR DESCRIPTION
Discovered while running the dicom-ups-rs-client (server_flavor=standard) end-to-end against py-ups-rs.

- WorkItemsResource.on_post (create): honour the "?workitem={UID}" URL query parameter per PS3.18 §11.5.1 when SOPInstanceUID is absent from the request body. Previously failed with HTTP 500 "'Dataset' object has no attribute 'SOPInstanceUID'".

- WorkItemResource.on_put -> on_post: PS3.18 §11.6.1 specifies POST (not PUT) for Update Workitem. Also accept both "Transaction-uid" (the PS3.18 URI template form) and the legacy lowercase "transaction-uid" as the query parameter name.

- Split cancel handling out of WorkItemResource into a new WorkItemCancelRequestResource at "/workitems/{UID}/cancelrequest" per PS3.18 §11.8. The previous layout treated POST /workitems/{UID} (which is the Update URL per §11.6) as a cancel, which conflicted with the corrected update routing.

- WorkItemCancelRequestResource uses deserialize_request_body so the cancel endpoint accepts both application/dicom+json and application/dicom+xml; the previous cancel handler was JSON-only. All four UPS-RS workitem handlers (create / update / state / cancel) now route body parsing through the same content-type dispatcher.

End-to-end verified against py-ups-rs in both JSON and XML for the full SCHEDULED -> IN PROGRESS -> update -> COMPLETED lifecycle, plus the SCHEDULED -> request-cancel and IN PROGRESS -> CANCELED paths.

## Summary by Sourcery

Align UPS-RS workitem create, update, and cancel endpoints with DICOM PS3.18 transactions and content-negotiation requirements.

Bug Fixes:
- Prevent crashes on workitem creation by deriving the SOP Instance UID from the workitem query parameter when it is absent from the request body.
- Correct the HTTP method for updating a workitem to use POST and accept both PS3.18-compliant and legacy transaction UID query parameter names.

Enhancements:
- Introduce a dedicated cancel-request workitem resource that follows the PS3.18 cancel transaction semantics and routing.
- Unify request body parsing for cancel requests so the endpoint accepts both DICOM JSON and XML using the shared content-type negotiation logic.