### PR TITLE
fix: get_filtered tolerates rows without SOPInstanceUID; harden on_get

### DIFF
--- a/pyupsrs/api/resources/workitems.py
+++ b/pyupsrs/api/resources/workitems.py
@@ -163,62 +163,83 @@ class WorkItemsResource(LoggerMixin):
             resp: The HTTP response.
 
         """
-        if workitem_uid := req.get_param("workitem"):
-            # Retrieve workitem transaction.  Might need to return just the one item rather than a list of one item
-            workitem_list = [self.workitem_service.workitem_repository.get_by_uid(workitem_uid)]
-        else:
-            params = dict(req.params)
-            # match = req.get_param("match")
-            non_match_param_list = ["includefield", "fuzzymatching", "offset", "limit"]
-            include_field = req.get_param("includefield")
-            fuzzy_matching = req.get_param("fuzzymatching")
-            offset = req.get_param_as_int("offset")
-            limit = req.get_param_as_int("limit")
-            # strip out anything that we know is not a tag or keyword
-            for non_match_param in non_match_param_list:
-                if non_match_param in params:
-                    del params[non_match_param]
-
-            # what's left is a list of matching parameters, either as keywords or as hex values
-            query_ds = Dataset()
-            for key, value in params.items():
-                try:
-                    tag = int(key, base=16)
-
-                    query_ds.add(DataElement(tag=tag, VR=datadict.dictionary_VR(tag), value=value))
-                except ValueError:
-                    try:
-                        keyword = key
-                        query_ds.add(DataElement(tag=keyword, VR=datadict.dictionary_VR(keyword), value=value))
-                    except ValueError:
-                        self.logger.error(f"Matching element had invalid tag or keyword: {key}")
-
-            workitem_list = self.workitem_service.workitem_repository.get_filtered(
-                match=query_ds,
-                include_field=include_field.split(",") if include_field else [],
-                fuzzy_matching=fuzzy_matching,
-                offset=offset,
-                limit=limit,
-            )
-
-        resp.content_type = negotiate_content_type(req)
-        if workitem_list and len(workitem_list) > 0 and workitem_list[0] is not None and workitem_list[0].ds is not None:
-            dataset_list = [x.ds for x in workitem_list]
-            resp.status = falcon.HTTP_200
-            try:
-                data, resp.content_type = serialize_dataset_list(dataset_list, resp.content_type)
-            except Exception as e:
-                print(f"Failed to serialise result: {e}")
-                resp.status = falcon.HTTP_500
-                return
-
-            if isinstance(data, bytes):
-                resp.data = data
+        try:
+            if workitem_uid := req.get_param("workitem"):
+                # Retrieve workitem transaction.  Might need to return just the one item rather than a list of one item
+                workitem_list = [self.workitem_service.workitem_repository.get_by_uid(workitem_uid)]
             else:
-                resp.text = data
+                params = dict(req.params)
+                # match = req.get_param("match")
+                non_match_param_list = ["includefield", "fuzzymatching", "offset", "limit"]
+                include_field = req.get_param("includefield")
+                fuzzy_matching = req.get_param("fuzzymatching")
+                offset = req.get_param_as_int("offset")
+                limit = req.get_param_as_int("limit")
+                # strip out anything that we know is not a tag or keyword
+                for non_match_param in non_match_param_list:
+                    if non_match_param in params:
+                        del params[non_match_param]
 
-        else:
-            resp.status = falcon.HTTP_404
+                # what's left is a list of matching parameters, either as keywords or as hex values
+                query_ds = Dataset()
+                for key, value in params.items():
+                    try:
+                        tag = int(key, base=16)
+
+                        query_ds.add(DataElement(tag=tag, VR=datadict.dictionary_VR(tag), value=value))
+                    except ValueError:
+                        try:
+                            keyword = key
+                            query_ds.add(DataElement(tag=keyword, VR=datadict.dictionary_VR(keyword), value=value))
+                        except ValueError:
+                            self.logger.error(f"Matching element had invalid tag or keyword: {key}")
+
+                workitem_list = self.workitem_service.workitem_repository.get_filtered(
+                    match=query_ds,
+                    include_field=include_field.split(",") if include_field else [],
+                    fuzzy_matching=fuzzy_matching,
+                    offset=offset,
+                    limit=limit,
+                )
+
+            resp.content_type = negotiate_content_type(req)
+            if workitem_list and len(workitem_list) > 0 and workitem_list[0] is not None and workitem_list[0].ds is not None:
+                dataset_list = [x.ds for x in workitem_list]
+                resp.status = falcon.HTTP_200
+                try:
+                    data, resp.content_type = serialize_dataset_list(dataset_list, resp.content_type)
+                except Exception as e:
+                    # Log only the exception type; the message could contain
+                    # dataset/PHI content for some pydicom serializer errors.
+                    self.logger.error(
+                        "Failed to serialise workitem search result (exception type: %s)",
+                        type(e).__name__,
+                    )
+                    raise falcon.HTTPInternalServerError(
+                        title="Internal server error",
+                        description="Failed to serialize search response.",
+                    ) from e
+
+                if isinstance(data, bytes):
+                    resp.data = data
+                else:
+                    resp.text = data
+
+            else:
+                resp.status = falcon.HTTP_404
+
+        except falcon.HTTPError:
+            raise
+        except Exception as e:
+            # Log only the exception type; messages from deeper layers may
+            # contain dataset/PHI content.
+            self.logger.error(
+                "Unhandled error processing workitem search request (exception type: %s)",
+                type(e).__name__,
+            )
+            raise falcon.HTTPInternalServerError(
+                title="Internal server error", description="An unexpected error occurred."
+            ) from e
 
     async def on_post(self, req: falcon.Request, resp: falcon.Response) -> None:
         """

--- a/pyupsrs/api/resources/workitems.py
+++ b/pyupsrs/api/resources/workitems.py
@@ -203,7 +203,7 @@ class WorkItemsResource(LoggerMixin):
                 )
 
             resp.content_type = negotiate_content_type(req)
-            if workitem_list and len(workitem_list) > 0 and workitem_list[0] is not None and workitem_list[0].ds is not None:
+            if workitem_list and workitem_list[0] is not None and workitem_list[0].ds is not None:
                 dataset_list = [x.ds for x in workitem_list]
                 resp.status = falcon.HTTP_200
                 try:

--- a/pyupsrs/storage/repositories/workitem_repository.py
+++ b/pyupsrs/storage/repositories/workitem_repository.py
@@ -217,7 +217,18 @@ class WorkItemRepository(LoggerMixin):
         all_workitems = self.get_all()
         datasets = [x.ds for x in all_workitems]
         matching_datasets = query_datasets(query=match, datasets=datasets)
-        uid_list = [str(x.SOPInstanceUID) for x in matching_datasets]
+        uid_list: list[str] = []
+        for matching_ds in matching_datasets:
+            # SOPInstanceUID (0008,0018) is preferred; AffectedSOPInstanceUID
+            # (0000,1000) is the legacy fallback. Skip datasets that have
+            # neither (orphaned rows from earlier development cycles); they
+            # cannot be looked up by UID and would otherwise raise
+            # AttributeError on str(ds.SOPInstanceUID), surfacing as a 500.
+            ds_uid = getattr(matching_ds, "SOPInstanceUID", None) or getattr(matching_ds, "AffectedSOPInstanceUID", None)
+            if ds_uid is None:
+                self.logger.warning("Skipping matched workitem dataset without SOPInstanceUID or AffectedSOPInstanceUID")
+                continue
+            uid_list.append(str(ds_uid))
         matching_workitems = [wi for wi in all_workitems if wi.uid in uid_list]
         copy_of_workitems = deepcopy(matching_workitems)
 

--- a/pyupsrs/storage/repositories/workitem_repository.py
+++ b/pyupsrs/storage/repositories/workitem_repository.py
@@ -217,7 +217,7 @@ class WorkItemRepository(LoggerMixin):
         all_workitems = self.get_all()
         datasets = [x.ds for x in all_workitems]
         matching_datasets = query_datasets(query=match, datasets=datasets)
-        uid_list: list[str] = []
+        uid_set: set[str] = set()
         for matching_ds in matching_datasets:
             # SOPInstanceUID (0008,0018) is preferred; AffectedSOPInstanceUID
             # (0000,1000) is the legacy fallback. Skip datasets that have
@@ -228,8 +228,8 @@ class WorkItemRepository(LoggerMixin):
             if ds_uid is None:
                 self.logger.warning("Skipping matched workitem dataset without SOPInstanceUID or AffectedSOPInstanceUID")
                 continue
-            uid_list.append(str(ds_uid))
-        matching_workitems = [wi for wi in all_workitems if wi.uid in uid_list]
+            uid_set.add(str(ds_uid))
+        matching_workitems = [wi for wi in all_workitems if wi.uid in uid_set]
         copy_of_workitems = deepcopy(matching_workitems)
 
         if include_field and "all" not in include_field:

--- a/tests/unit/storage/test_workitem_repository.py
+++ b/tests/unit/storage/test_workitem_repository.py
@@ -163,6 +163,62 @@ class TestGetAll:
         assert len(result) == 3
 
 
+class TestGetFilteredOrphanedWorkitems:
+    """
+    Contract: get_filtered must not crash on rows lacking SOPInstanceUID.
+
+    Orphaned workitem rows (from earlier development cycles where
+    SOPInstanceUID was not injected from the URL on create) have
+    neither (0008,0018) SOPInstanceUID nor (0000,1000)
+    AffectedSOPInstanceUID. Previously get_filtered raised
+    AttributeError on ``str(ds.SOPInstanceUID)``, surfacing as a
+    500 to the API caller. The fix silently skips such rows.
+    """
+
+    def _insert_orphan_row(self, repo: WorkItemRepository) -> None:
+        """Insert a workitem row with no SOPInstanceUID via direct SQL."""
+        # Mimic the legacy bad state: dataset_json has filterable content
+        # (status, patient ID) but no SOPInstanceUID / AffectedSOPInstanceUID.
+        orphan_json = (
+            '{"00100010": {"vr": "PN", '
+            '"Value": [{"Alphabetic": "Orphan^Patient"}]}, '
+            '"00100020": {"vr": "LO", "Value": ["ORPHAN-001"]}, '
+            '"00741000": {"vr": "CS", "Value": ["SCHEDULED"]}}'
+        )
+        repo._db.execute(
+            "INSERT INTO workitems (uid, status, dataset_json, created_at) VALUES (?, ?, ?, ?)",
+            ("orphan-no-sop-uid", "SCHEDULED", orphan_json, "1970-01-01"),
+        )
+
+    def test_filter_with_orphaned_row_does_not_crash(self, repo: WorkItemRepository) -> None:
+        """Verify filtered search skips orphans rather than raising."""
+        # A normal workitem the filter should match.
+        good_uid = generate_uid()
+        ds = Dataset()
+        ds.SOPInstanceUID = good_uid
+        ds.PatientName = "Real^Patient"
+        ds.ProcedureStepState = "SCHEDULED"
+        wi = WorkItem(ds=ds)
+        wi.status = WorkItemStatus.SCHEDULED
+        repo.create(wi)
+
+        # An orphan row that would otherwise raise AttributeError.
+        self._insert_orphan_row(repo)
+
+        query = Dataset()
+        query.ProcedureStepState = "SCHEDULED"
+
+        results = repo.get_filtered(match=query)
+
+        # The good workitem is returned; the orphan is silently dropped.
+        returned_uids = [r.uid for r in results]
+        assert good_uid in returned_uids
+        # Orphan uid (as stored in the uid column) is NOT in returned set
+        # because get_filtered re-keys by the dataset's SOPInstanceUID,
+        # which the orphan does not have.
+        assert "orphan-no-sop-uid" not in returned_uids
+
+
 class TestDatasetRoundTrip:
     """Contract: Dataset serialization preserves all DICOM attributes."""
 


### PR DESCRIPTION
## Summary

- `WorkItemRepository.get_filtered` previously raised `AttributeError` on `str(ds.SOPInstanceUID)` for matched datasets without `(0008,0018)` SOPInstanceUID — surfacing as a generic 500 to the API caller. Orphaned rows from earlier development cycles (where the UID wasn't injected from the URL on create) trip this. Fix: skip such rows with a logged warning, fallback to `(0000,1000)` AffectedSOPInstanceUID.
- `WorkItemListResource.on_get` now wraps its body in try/except so any future unexpected exception surfaces as a `falcon.HTTPInternalServerError` with the exception type logged. The previous handler only `print()`'d serializer errors, swallowing everything else.
- PHI safety: new error handlers log only the exception **type name**, never the exception message — deeper-layer exceptions can include dataset content (patient name, etc.) in their `str` representation.

## Out of scope (raise as follow-up if wanted)

The pre-existing `on_post` handlers in this file use `logger.exception` with the full traceback. Same PHI risk. A broader hardening pass across all resources would tighten that consistently.

## Test plan

- [x] New regression test `TestGetFilteredOrphanedWorkitems::test_filter_with_orphaned_row_does_not_crash` inserts an orphaned row via direct SQL, runs a filtered search, asserts the orphan is silently dropped rather than crashing the request.
- [x] Full repository test file (`tests/unit/storage/test_workitem_repository.py`): 17 passed.
- [x] Full unit + integration suite (`pytest tests/`): 349 passed, no regressions.
- [x] Live verification against a server with mixed clean + orphan rows: previously `GET /workitems?00741000=SCHEDULED` returned 500; now returns 200 with the correct subset.
- [x] Pre-commit hooks (ruff, ruff-format, trailing whitespace, EOF): pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Handle orphaned workitems lacking SOPInstanceUID in filtered queries and harden the workitem list GET endpoint error handling.

Bug Fixes:
- Prevent workitem filtered searches from crashing when matched datasets lack SOPInstanceUID by skipping such rows with a logged warning and falling back to AffectedSOPInstanceUID where available.

Enhancements:
- Wrap the workitem list GET handler in robust error handling that converts unexpected exceptions into HTTP 500 responses while logging only the exception type to avoid leaking PHI.
- Improve logging for serialization and request-processing errors in the workitem list endpoint to report exception types without including potentially sensitive dataset content.

Tests:
- Add regression coverage ensuring get_filtered ignores orphaned workitem rows without SOPInstanceUID while still returning valid matches.